### PR TITLE
button_hold_camera: embed GPS/IMU metadata in NIR captures

### DIFF
--- a/button_hold_camera.py
+++ b/button_hold_camera.py
@@ -144,43 +144,36 @@ except Exception as exc:
     print(f"Camera loading error: {exc}")
 
 _metadata_writer: Optional[Callable[[str], None]] = None
-_metadata_writer_initialized = False
+_metadata_writer_attempted = False
 _metadata_writer_last_attempt_ts: float = 0.0
 _metadata_writer_retry_backoff_sec: float = 30.0
 
 
 def _get_metadata_writer() -> Optional[Callable[[str], None]]:
     """Lazily load metadata helper so systems without GPS/IMU deps still run."""
-    global _metadata_writer, _metadata_writer_initialized, _metadata_writer_last_attempt_ts
+    global _metadata_writer, _metadata_writer_attempted, _metadata_writer_last_attempt_ts
     if _metadata_writer is not None:
-        _metadata_writer_initialized = True
         return _metadata_writer
 
     now = time.monotonic()
-    if _metadata_writer_initialized and (now - _metadata_writer_last_attempt_ts) < _metadata_writer_retry_backoff_sec:
+    if _metadata_writer_attempted and (now - _metadata_writer_last_attempt_ts) < _metadata_writer_retry_backoff_sec:
         return None
     _metadata_writer_last_attempt_ts = now
 
     repo_root = REPO_ROOT
-    tools_dir = path.join(REPO_ROOT, "tools")
-    # Make both `tools.*` and plain modules inside `tools/` importable.
-    # - `import tools.add_metadata` requires the repo root on sys.path.
-    # - `import add_metadata` (tools/add_metadata.py) requires tools_dir on sys.path.
+    # `import tools.add_metadata` requires the repo root on sys.path.
+    # Append rather than insert(0) to avoid shadowing stdlib modules.
     if path.isdir(repo_root) and repo_root not in sys.path:
-        sys.path.insert(0, repo_root)
-    if path.isdir(tools_dir) and tools_dir not in sys.path:
-        sys.path.insert(0, tools_dir)
+        sys.path.append(repo_root)
     try:
         last_error: Optional[Exception] = None
-        for module_name in ("tools.add_metadata", "add_metadata"):
-            try:
-                metadata_module = importlib.import_module(module_name)
-                writer = getattr(metadata_module, "add_metadata", None)
-                if callable(writer):
-                    _metadata_writer = writer
-                    break
-            except Exception as exc:
-                last_error = exc
+        try:
+            metadata_module = importlib.import_module("tools.add_metadata")
+            writer = getattr(metadata_module, "add_metadata", None)
+            if callable(writer):
+                _metadata_writer = writer
+        except Exception as exc:
+            last_error = exc
         if _metadata_writer is None:
             if last_error is not None:
                 # Expected on units without metadata dependencies or sensors.
@@ -190,9 +183,9 @@ def _get_metadata_writer() -> Optional[Callable[[str], None]]:
     except Exception as exc:
         print(f"Metadata helper unavailable; continuing without metadata: {exc}")
     finally:
-        # Mark initialized only after at least one real attempt. If it failed, we still allow
+        # Mark attempted only after at least one real attempt. If it failed, we still allow
         # occasional retries (backoff) in case the environment becomes ready later.
-        _metadata_writer_initialized = True
+        _metadata_writer_attempted = True
     return _metadata_writer
 
 
@@ -209,19 +202,22 @@ def _maybe_add_sensor_metadata(image_path: Optional[str]) -> None:
     except Exception as exc:
         print(f"Metadata write failed for {image_path}: {exc}")
 
-def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
+def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], Optional[str], bool]:
     """Two full-resolution stills in one Picamera2 session: ``start()`` → OFF → ON → ``stop()``.
 
     Faster than two ``start_and_capture_file`` calls (benchmark C/D NIR path). Pipeline is idle after
     ``stop()`` before ``flir()`` unless ``PARALLEL_FLIR_WITH_PICAM`` overlaps Flir in another thread.
 
-    Returns (nir_off_path, full_pair_saved).
+    Returns (nir_off_path, nir_on_path, full_pair_saved).
     - nir_off_path is set when the NIR-OFF frame is saved, even if NIR-ON later fails.
+    - nir_on_path is set only when the NIR-ON frame is saved.
     - full_pair_saved is True only when both NIR-OFF and NIR-ON were saved.
+    Metadata writes are intentionally omitted here; callers should apply them after
+    releasing any capture lock so that GPS retries do not block subsequent presses.
     """
     if picam2 is None:
         print("Picamera2 not initialized; skipping NIR pair")
-        return None, False
+        return None, None, False
 
     for attempt in range(1, NIR_PAIR_MAX_ATTEMPTS + 1):
         nir_off_saved: Optional[str] = None
@@ -256,22 +252,15 @@ def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
                 picam2.stop()
             except Exception as exc:
                 print(f"Picamera2 stop failed (attempt {attempt}/{NIR_PAIR_MAX_ATTEMPTS}): {exc}")
-            # Embed metadata after captures to keep OFF/ON timing tight.
-            try:
-                _maybe_add_sensor_metadata(nir_off_saved)
-                _maybe_add_sensor_metadata(nir_on_saved)
-            except Exception:
-                # _maybe_add_sensor_metadata() is already best-effort; avoid perturbing capture retries.
-                pass
 
         if pair_saved:
-            return nir_off_saved, True
+            return nir_off_saved, nir_on_saved, True
         if nir_off_saved is not None:
-            return nir_off_saved, False
+            return nir_off_saved, None, False
         if attempt < NIR_PAIR_MAX_ATTEMPTS:
             time.sleep(NIR_PAIR_RETRY_DELAY_SEC)
 
-    return None, False
+    return None, None, False
 
 def flir(session_dir: str) -> None:
     """Flir Lepton 3.5: run capture then lepton sequentially in ``session_dir`` (same folder as NIR stills).
@@ -386,7 +375,7 @@ def _join_flir_thread(flir_thread: threading.Thread) -> None:
         )
 
 
-def photos(images_root: str) -> Tuple[Optional[str], bool, str]:
+def photos(images_root: str) -> Tuple[Optional[str], Optional[str], bool, str]:
     """Create one session folder per press; NIR JPEGs and FLIR PGM/CSV all use that same path."""
     date = datetime.now().strftime('%Y%m%d-%H%M%S')
     session_dir = path.join(images_root, date)
@@ -395,7 +384,6 @@ def photos(images_root: str) -> Tuple[Optional[str], bool, str]:
 
     if nir_control_led is None:
         print("NIR control LED not initialized; skipping NIR pair, running FLIR only")
-        basename: Optional[str] = None
         if PARALLEL_FLIR_WITH_PICAM:
             flir_thread = threading.Thread(target=_run_flir_safe, args=(session_dir,), name="flir")
             flir_started = False
@@ -407,9 +395,10 @@ def photos(images_root: str) -> Tuple[Optional[str], bool, str]:
                     _join_flir_thread(flir_thread)
         else:
             _run_flir_safe(session_dir)
-        return basename, False, session_dir
+        return None, None, False, session_dir
 
-    basename: Optional[str] = None
+    nir_off: Optional[str] = None
+    nir_on: Optional[str] = None
     pair_saved = False
     if PARALLEL_FLIR_WITH_PICAM:
         flir_thread = threading.Thread(target=_run_flir_safe, args=(session_dir,), name="flir")
@@ -417,21 +406,22 @@ def photos(images_root: str) -> Tuple[Optional[str], bool, str]:
         try:
             flir_thread.start()
             flir_started = True
-            basename, pair_saved = take_nir_pair(session_dir, nir_control_led)
+            nir_off, nir_on, pair_saved = take_nir_pair(session_dir, nir_control_led)
         finally:
             if flir_started:
                 _join_flir_thread(flir_thread)
     else:
-        basename, pair_saved = take_nir_pair(session_dir, nir_control_led)
+        nir_off, nir_on, pair_saved = take_nir_pair(session_dir, nir_control_led)
         _run_flir_safe(session_dir)
 
-    return basename, pair_saved, session_dir
+    return nir_off, nir_on, pair_saved, session_dir
 
 def single_press(button):
     print(f"Button DOWN on pin {button.pin}")
 
     blocked_by_stuck_flir = False
     nir_off_name: Optional[str] = None
+    nir_on_name: Optional[str] = None
     nir_pair_saved = False
     directory = ""
     try:
@@ -442,10 +432,15 @@ def single_press(button):
                 try:
                     if status_led is not None:
                         status_led.on()
-                    nir_off_name, nir_pair_saved, directory = photos(IMAGES_ROOT)
+                    nir_off_name, nir_on_name, nir_pair_saved, directory = photos(IMAGES_ROOT)
                 finally:
                     if status_led is not None:
                         status_led.off()
+
+        # Metadata writes (GPS lookup ~3 s) happen after releasing the lock so a subsequent
+        # button press is not blocked while sensor data is being fetched.
+        _maybe_add_sensor_metadata(nir_off_name)
+        _maybe_add_sensor_metadata(nir_on_name)
 
         # Feedback can take ~2s (blocking blink/beep); run only after releasing the lock so the next
         # press is not delayed — the lock serializes capture hardware, not UI.

--- a/button_hold_camera.py
+++ b/button_hold_camera.py
@@ -12,7 +12,6 @@ from typing import Callable, Optional, Tuple
 import subprocess
 import threading
 import time
-import importlib
 import importlib.util
 import sys
 from glob import glob
@@ -148,58 +147,89 @@ _metadata_writer: Optional[Callable[[str], None]] = None
 _metadata_writer_attempted = False
 _metadata_writer_last_attempt_ts: float = 0.0
 _metadata_writer_retry_backoff_sec: float = 30.0
+# Serializes _get_metadata_writer() so concurrent single_press() calls cannot
+# race on the attempted flag, backoff timestamp, or exec_module.
+_metadata_writer_lock = threading.Lock()
 
 
 def _get_metadata_writer() -> Optional[Callable[[str], None]]:
     """Lazily load metadata helper so systems without GPS/IMU deps still run."""
     global _metadata_writer, _metadata_writer_attempted, _metadata_writer_last_attempt_ts
+    # Fast path: writer already loaded — check without acquiring the lock.
     if _metadata_writer is not None:
         return _metadata_writer
 
-    now = time.monotonic()
-    if _metadata_writer_attempted and (now - _metadata_writer_last_attempt_ts) < _metadata_writer_retry_backoff_sec:
-        return None
-    _metadata_writer_last_attempt_ts = now
+    with _metadata_writer_lock:
+        # Re-check under the lock; another thread may have loaded it while we waited.
+        if _metadata_writer is not None:
+            return _metadata_writer
 
-    repo_root = REPO_ROOT
-    metadata_path = path.join(repo_root, "tools", "add_metadata.py")
-    # add_metadata.py itself uses `from tools import bno055_imu` and
-    # `from tools.get_gps import ...`, so repo_root must be on sys.path for
-    # those transitive imports to resolve.  We append (not insert) to avoid
-    # accidentally shadowing stdlib modules.
-    if path.isdir(repo_root) and repo_root not in sys.path:
-        sys.path.append(repo_root)
-    try:
-        last_error: Optional[Exception] = None
+        now = time.monotonic()
+        if _metadata_writer_attempted and (now - _metadata_writer_last_attempt_ts) < _metadata_writer_retry_backoff_sec:
+            return None
+        _metadata_writer_last_attempt_ts = now
+
+        repo_root = REPO_ROOT
+        metadata_path = path.join(repo_root, "tools", "add_metadata.py")
         try:
-            # Use spec_from_file_location so we always load THIS repo's
-            # add_metadata.py by explicit path, regardless of what other
-            # packages named `tools` may exist earlier on sys.path.
-            if not path.isfile(metadata_path):
-                raise FileNotFoundError(f"add_metadata.py not found at {metadata_path}")
-            spec = importlib.util.spec_from_file_location("watercam_add_metadata", metadata_path)
-            if spec is None or spec.loader is None:
-                raise ImportError(f"Could not create module spec for {metadata_path}")
-            metadata_module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(metadata_module)  # type: ignore[union-attr]
-            writer = getattr(metadata_module, "add_metadata", None)
-            if callable(writer):
-                _metadata_writer = writer
+            last_error: Optional[Exception] = None
+            try:
+                # Load add_metadata.py by explicit file path so we always get
+                # THIS repo's copy, regardless of what other packages named
+                # `tools` may exist on sys.path.
+                if not path.isfile(metadata_path):
+                    raise FileNotFoundError(f"add_metadata.py not found at {metadata_path}")
+                spec = importlib.util.spec_from_file_location("watercam_add_metadata", metadata_path)
+                if spec is None or spec.loader is None:
+                    raise ImportError(f"Could not create module spec for {metadata_path}")
+                metadata_module = importlib.util.module_from_spec(spec)
+                # add_metadata.py uses `from tools import bno055_imu` and
+                # `from tools.get_gps import ...`.  Temporarily insert repo_root
+                # at the front of sys.path so those transitive imports resolve to
+                # THIS repo's tools/ package, then restore sys.path immediately.
+                _inserted = False
+                if repo_root not in sys.path:
+                    sys.path.insert(0, repo_root)
+                    _inserted = True
+                else:
+                    # Move repo_root to the front so it wins over any earlier
+                    # `tools` package that may have been on the path already.
+                    _orig_idx = sys.path.index(repo_root)
+                    sys.path.insert(0, sys.path.pop(_orig_idx))
+                    _inserted = False  # we'll restore by moving it back
+                try:
+                    spec.loader.exec_module(metadata_module)  # type: ignore[union-attr]
+                finally:
+                    if _inserted:
+                        try:
+                            sys.path.remove(repo_root)
+                        except ValueError:
+                            pass
+                    else:
+                        # Restore repo_root to its original position.
+                        try:
+                            sys.path.remove(repo_root)
+                            sys.path.insert(_orig_idx, repo_root)  # type: ignore[possibly-undefined]
+                        except ValueError:
+                            pass
+                writer = getattr(metadata_module, "add_metadata", None)
+                if callable(writer):
+                    _metadata_writer = writer
+            except Exception as exc:
+                last_error = exc
+            if _metadata_writer is None:
+                if last_error is not None:
+                    # Expected on units without metadata dependencies or sensors.
+                    print(f"Metadata helper unavailable; continuing without metadata: {last_error}")
+                else:
+                    print("Metadata helper found but add_metadata() is missing; continuing without metadata")
         except Exception as exc:
-            last_error = exc
-        if _metadata_writer is None:
-            if last_error is not None:
-                # Expected on units without metadata dependencies or sensors.
-                print(f"Metadata helper unavailable; continuing without metadata: {last_error}")
-            else:
-                print("Metadata helper found but add_metadata() is missing; continuing without metadata")
-    except Exception as exc:
-        print(f"Metadata helper unavailable; continuing without metadata: {exc}")
-    finally:
-        # Mark attempted only after at least one real attempt. If it failed, we still allow
-        # occasional retries (backoff) in case the environment becomes ready later.
-        _metadata_writer_attempted = True
-    return _metadata_writer
+            print(f"Metadata helper unavailable; continuing without metadata: {exc}")
+        finally:
+            # Mark attempted only after at least one real attempt. If it failed, we still allow
+            # occasional retries (backoff) in case the environment becomes ready later.
+            _metadata_writer_attempted = True
+        return _metadata_writer
 
 
 def _maybe_add_sensor_metadata(image_path: Optional[str]) -> None:

--- a/button_hold_camera.py
+++ b/button_hold_camera.py
@@ -13,6 +13,7 @@ import subprocess
 import threading
 import time
 import importlib
+import importlib.util
 import sys
 from glob import glob
 from signal import pause
@@ -161,14 +162,26 @@ def _get_metadata_writer() -> Optional[Callable[[str], None]]:
     _metadata_writer_last_attempt_ts = now
 
     repo_root = REPO_ROOT
-    # `import tools.add_metadata` requires the repo root on sys.path.
-    # Append rather than insert(0) to avoid shadowing stdlib modules.
+    metadata_path = path.join(repo_root, "tools", "add_metadata.py")
+    # add_metadata.py itself uses `from tools import bno055_imu` and
+    # `from tools.get_gps import ...`, so repo_root must be on sys.path for
+    # those transitive imports to resolve.  We append (not insert) to avoid
+    # accidentally shadowing stdlib modules.
     if path.isdir(repo_root) and repo_root not in sys.path:
         sys.path.append(repo_root)
     try:
         last_error: Optional[Exception] = None
         try:
-            metadata_module = importlib.import_module("tools.add_metadata")
+            # Use spec_from_file_location so we always load THIS repo's
+            # add_metadata.py by explicit path, regardless of what other
+            # packages named `tools` may exist earlier on sys.path.
+            if not path.isfile(metadata_path):
+                raise FileNotFoundError(f"add_metadata.py not found at {metadata_path}")
+            spec = importlib.util.spec_from_file_location("watercam_add_metadata", metadata_path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not create module spec for {metadata_path}")
+            metadata_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(metadata_module)  # type: ignore[union-attr]
             writer = getattr(metadata_module, "add_metadata", None)
             if callable(writer):
                 _metadata_writer = writer

--- a/button_hold_camera.py
+++ b/button_hold_camera.py
@@ -171,64 +171,43 @@ def _get_metadata_writer() -> Optional[Callable[[str], None]]:
 
         repo_root = REPO_ROOT
         metadata_path = path.join(repo_root, "tools", "add_metadata.py")
+        last_error: Optional[Exception] = None
         try:
-            last_error: Optional[Exception] = None
+            # Load add_metadata.py by explicit file path so we always get
+            # THIS repo's copy, regardless of what other packages named
+            # `tools` may exist on sys.path.
+            if not path.isfile(metadata_path):
+                raise FileNotFoundError(f"add_metadata.py not found at {metadata_path}")
+            spec = importlib.util.spec_from_file_location("watercam_add_metadata", metadata_path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not create module spec for {metadata_path}")
+            metadata_module = importlib.util.module_from_spec(spec)
+            # add_metadata.py uses `from tools import bno055_imu` and
+            # `from tools.get_gps import ...`.  Temporarily front repo_root on
+            # sys.path so those transitive imports resolve to THIS repo's tools/
+            # package, then restore sys.path to its exact prior state.
+            _saved_path = list(sys.path)
+            if repo_root not in sys.path or sys.path[0] != repo_root:
+                sys.path.insert(0, repo_root)
             try:
-                # Load add_metadata.py by explicit file path so we always get
-                # THIS repo's copy, regardless of what other packages named
-                # `tools` may exist on sys.path.
-                if not path.isfile(metadata_path):
-                    raise FileNotFoundError(f"add_metadata.py not found at {metadata_path}")
-                spec = importlib.util.spec_from_file_location("watercam_add_metadata", metadata_path)
-                if spec is None or spec.loader is None:
-                    raise ImportError(f"Could not create module spec for {metadata_path}")
-                metadata_module = importlib.util.module_from_spec(spec)
-                # add_metadata.py uses `from tools import bno055_imu` and
-                # `from tools.get_gps import ...`.  Temporarily insert repo_root
-                # at the front of sys.path so those transitive imports resolve to
-                # THIS repo's tools/ package, then restore sys.path immediately.
-                _inserted = False
-                if repo_root not in sys.path:
-                    sys.path.insert(0, repo_root)
-                    _inserted = True
-                else:
-                    # Move repo_root to the front so it wins over any earlier
-                    # `tools` package that may have been on the path already.
-                    _orig_idx = sys.path.index(repo_root)
-                    sys.path.insert(0, sys.path.pop(_orig_idx))
-                    _inserted = False  # we'll restore by moving it back
-                try:
-                    spec.loader.exec_module(metadata_module)  # type: ignore[union-attr]
-                finally:
-                    if _inserted:
-                        try:
-                            sys.path.remove(repo_root)
-                        except ValueError:
-                            pass
-                    else:
-                        # Restore repo_root to its original position.
-                        try:
-                            sys.path.remove(repo_root)
-                            sys.path.insert(_orig_idx, repo_root)  # type: ignore[possibly-undefined]
-                        except ValueError:
-                            pass
-                writer = getattr(metadata_module, "add_metadata", None)
-                if callable(writer):
-                    _metadata_writer = writer
-            except Exception as exc:
-                last_error = exc
-            if _metadata_writer is None:
-                if last_error is not None:
-                    # Expected on units without metadata dependencies or sensors.
-                    print(f"Metadata helper unavailable; continuing without metadata: {last_error}")
-                else:
-                    print("Metadata helper found but add_metadata() is missing; continuing without metadata")
+                spec.loader.exec_module(metadata_module)  # type: ignore[union-attr]
+            finally:
+                sys.path[:] = _saved_path
+            writer = getattr(metadata_module, "add_metadata", None)
+            if callable(writer):
+                _metadata_writer = writer
         except Exception as exc:
-            print(f"Metadata helper unavailable; continuing without metadata: {exc}")
+            last_error = exc
         finally:
             # Mark attempted only after at least one real attempt. If it failed, we still allow
             # occasional retries (backoff) in case the environment becomes ready later.
             _metadata_writer_attempted = True
+        if _metadata_writer is None:
+            if last_error is not None:
+                # Expected on units without metadata dependencies or sensors.
+                print(f"Metadata helper unavailable; continuing without metadata: {last_error}")
+            else:
+                print("Metadata helper found but add_metadata() is missing; continuing without metadata")
         return _metadata_writer
 
 
@@ -245,7 +224,7 @@ def _maybe_add_sensor_metadata(image_path: Optional[str]) -> None:
     except Exception as exc:
         print(f"Metadata write failed for {image_path}: {exc}")
 
-def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], Optional[str], bool]:
+def take_nir_pair(directory: str, pin: LED) -> Tuple[Optional[str], Optional[str], bool]:
     """Two full-resolution stills in one Picamera2 session: ``start()`` → OFF → ON → ``stop()``.
 
     Faster than two ``start_and_capture_file`` calls (benchmark C/D NIR path). Pipeline is idle after
@@ -422,8 +401,7 @@ def photos(images_root: str) -> Tuple[Optional[str], Optional[str], bool, str]:
     """Create one session folder per press; NIR JPEGs and FLIR PGM/CSV all use that same path."""
     date = datetime.now().strftime('%Y%m%d-%H%M%S')
     session_dir = path.join(images_root, date)
-    if not path.exists(session_dir):
-        makedirs(session_dir)
+    makedirs(session_dir, exist_ok=True)
 
     if nir_control_led is None:
         print("NIR control LED not initialized; skipping NIR pair, running FLIR only")

--- a/button_hold_camera.py
+++ b/button_hold_camera.py
@@ -150,6 +150,10 @@ _metadata_writer_retry_backoff_sec: float = 30.0
 # Serializes _get_metadata_writer() so concurrent single_press() calls cannot
 # race on the attempted flag, backoff timestamp, or exec_module.
 _metadata_writer_lock = threading.Lock()
+# Serializes add_metadata() calls. gpiozero runs button handlers in worker
+# threads, so back-to-back presses can reach _maybe_add_sensor_metadata()
+# concurrently. add_metadata() accesses GPS/IMU hardware and is not thread-safe.
+_metadata_write_lock = threading.Lock()
 
 
 def _get_metadata_writer() -> Optional[Callable[[str], None]]:
@@ -218,11 +222,12 @@ def _maybe_add_sensor_metadata(image_path: Optional[str]) -> None:
     writer = _get_metadata_writer()
     if writer is None:
         return
-    try:
-        writer(image_path)
-        print(f"Sensor metadata written: {image_path}")
-    except Exception as exc:
-        print(f"Metadata write failed for {image_path}: {exc}")
+    with _metadata_write_lock:
+        try:
+            writer(image_path)
+            print(f"Sensor metadata written: {image_path}")
+        except Exception as exc:
+            print(f"Metadata write failed for {image_path}: {exc}")
 
 def take_nir_pair(directory: str, pin: LED) -> Tuple[Optional[str], Optional[str], bool]:
     """Two full-resolution stills in one Picamera2 session: ``start()`` → OFF → ON → ``stop()``.
@@ -437,7 +442,7 @@ def photos(images_root: str) -> Tuple[Optional[str], Optional[str], bool, str]:
 
     return nir_off, nir_on, pair_saved, session_dir
 
-def single_press(button):
+def single_press(button: Button) -> None:
     print(f"Button DOWN on pin {button.pin}")
 
     blocked_by_stuck_flir = False

--- a/button_hold_camera.py
+++ b/button_hold_camera.py
@@ -145,17 +145,30 @@ except Exception as exc:
 
 _metadata_writer: Optional[Callable[[str], None]] = None
 _metadata_writer_initialized = False
+_metadata_writer_last_attempt_ts: float = 0.0
+_metadata_writer_retry_backoff_sec: float = 30.0
 
 
 def _get_metadata_writer() -> Optional[Callable[[str], None]]:
     """Lazily load metadata helper so systems without GPS/IMU deps still run."""
-    global _metadata_writer, _metadata_writer_initialized
-    if _metadata_writer_initialized:
+    global _metadata_writer, _metadata_writer_initialized, _metadata_writer_last_attempt_ts
+    if _metadata_writer is not None:
+        _metadata_writer_initialized = True
         return _metadata_writer
-    _metadata_writer_initialized = True
+
+    now = time.monotonic()
+    if _metadata_writer_initialized and (now - _metadata_writer_last_attempt_ts) < _metadata_writer_retry_backoff_sec:
+        return None
+    _metadata_writer_last_attempt_ts = now
+
+    repo_root = REPO_ROOT
     tools_dir = path.join(REPO_ROOT, "tools")
+    # Make both `tools.*` and plain modules inside `tools/` importable.
+    # - `import tools.add_metadata` requires the repo root on sys.path.
+    # - `import add_metadata` (tools/add_metadata.py) requires tools_dir on sys.path.
+    if path.isdir(repo_root) and repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
     if path.isdir(tools_dir) and tools_dir not in sys.path:
-        # Support deployed variants where add_metadata imports sibling modules as plain names.
         sys.path.insert(0, tools_dir)
     try:
         last_error: Optional[Exception] = None
@@ -176,6 +189,10 @@ def _get_metadata_writer() -> Optional[Callable[[str], None]]:
                 print("Metadata helper found but add_metadata() is missing; continuing without metadata")
     except Exception as exc:
         print(f"Metadata helper unavailable; continuing without metadata: {exc}")
+    finally:
+        # Mark initialized only after at least one real attempt. If it failed, we still allow
+        # occasional retries (backoff) in case the environment becomes ready later.
+        _metadata_writer_initialized = True
     return _metadata_writer
 
 
@@ -208,6 +225,7 @@ def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
 
     for attempt in range(1, NIR_PAIR_MAX_ATTEMPTS + 1):
         nir_off_saved: Optional[str] = None
+        nir_on_saved: Optional[str] = None
         pair_saved = False
         try:
             time_off = datetime.now().strftime('%Y%m%d-%H%M%S')
@@ -223,14 +241,13 @@ def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
             if (not path.exists(path_off)) or path.getsize(path_off) == 0:
                 raise RuntimeError(f"NIR-OFF file not written: {path_off}")
             nir_off_saved = path_off
-            _maybe_add_sensor_metadata(path_off)
             pin.on()
             print(f"Pin state is: {pin.value}")
             print(f"taking photo: {path_on}")
             picam2.capture_file(path_on)
             if (not path.exists(path_on)) or path.getsize(path_on) == 0:
                 raise RuntimeError(f"NIR-ON file not written: {path_on}")
-            _maybe_add_sensor_metadata(path_on)
+            nir_on_saved = path_on
             pair_saved = True
         except Exception as exc:
             print(f"Camera failed to capture (attempt {attempt}/{NIR_PAIR_MAX_ATTEMPTS}): {exc}")
@@ -239,6 +256,13 @@ def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
                 picam2.stop()
             except Exception as exc:
                 print(f"Picamera2 stop failed (attempt {attempt}/{NIR_PAIR_MAX_ATTEMPTS}): {exc}")
+            # Embed metadata after captures to keep OFF/ON timing tight.
+            try:
+                _maybe_add_sensor_metadata(nir_off_saved)
+                _maybe_add_sensor_metadata(nir_on_saved)
+            except Exception:
+                # _maybe_add_sensor_metadata() is already best-effort; avoid perturbing capture retries.
+                pass
 
         if pair_saved:
             return nir_off_saved, True

--- a/button_hold_camera.py
+++ b/button_hold_camera.py
@@ -8,10 +8,12 @@
 
 from os import path, makedirs, listdir, rename, environ
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 import subprocess
 import threading
 import time
+import importlib
+import sys
 from glob import glob
 from signal import pause
 from picamera2 import Picamera2
@@ -141,6 +143,55 @@ try:
 except Exception as exc:
     print(f"Camera loading error: {exc}")
 
+_metadata_writer: Optional[Callable[[str], None]] = None
+_metadata_writer_initialized = False
+
+
+def _get_metadata_writer() -> Optional[Callable[[str], None]]:
+    """Lazily load metadata helper so systems without GPS/IMU deps still run."""
+    global _metadata_writer, _metadata_writer_initialized
+    if _metadata_writer_initialized:
+        return _metadata_writer
+    _metadata_writer_initialized = True
+    tools_dir = path.join(REPO_ROOT, "tools")
+    if path.isdir(tools_dir) and tools_dir not in sys.path:
+        # Support deployed variants where add_metadata imports sibling modules as plain names.
+        sys.path.insert(0, tools_dir)
+    try:
+        last_error: Optional[Exception] = None
+        for module_name in ("tools.add_metadata", "add_metadata"):
+            try:
+                metadata_module = importlib.import_module(module_name)
+                writer = getattr(metadata_module, "add_metadata", None)
+                if callable(writer):
+                    _metadata_writer = writer
+                    break
+            except Exception as exc:
+                last_error = exc
+        if _metadata_writer is None:
+            if last_error is not None:
+                # Expected on units without metadata dependencies or sensors.
+                print(f"Metadata helper unavailable; continuing without metadata: {last_error}")
+            else:
+                print("Metadata helper found but add_metadata() is missing; continuing without metadata")
+    except Exception as exc:
+        print(f"Metadata helper unavailable; continuing without metadata: {exc}")
+    return _metadata_writer
+
+
+def _maybe_add_sensor_metadata(image_path: Optional[str]) -> None:
+    """Add EXIF/XMP sensor metadata only when metadata stack is available."""
+    if not image_path or not path.isfile(image_path):
+        return
+    writer = _get_metadata_writer()
+    if writer is None:
+        return
+    try:
+        writer(image_path)
+        print(f"Sensor metadata written: {image_path}")
+    except Exception as exc:
+        print(f"Metadata write failed for {image_path}: {exc}")
+
 def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
     """Two full-resolution stills in one Picamera2 session: ``start()`` → OFF → ON → ``stop()``.
 
@@ -172,12 +223,14 @@ def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
             if (not path.exists(path_off)) or path.getsize(path_off) == 0:
                 raise RuntimeError(f"NIR-OFF file not written: {path_off}")
             nir_off_saved = path_off
+            _maybe_add_sensor_metadata(path_off)
             pin.on()
             print(f"Pin state is: {pin.value}")
             print(f"taking photo: {path_on}")
             picam2.capture_file(path_on)
             if (not path.exists(path_on)) or path.getsize(path_on) == 0:
                 raise RuntimeError(f"NIR-ON file not written: {path_on}")
+            _maybe_add_sensor_metadata(path_on)
             pair_saved = True
         except Exception as exc:
             print(f"Camera failed to capture (attempt {attempt}/{NIR_PAIR_MAX_ATTEMPTS}): {exc}")
@@ -193,10 +246,6 @@ def take_nir_pair(directory: str, pin) -> Tuple[Optional[str], bool]:
             return nir_off_saved, False
         if attempt < NIR_PAIR_MAX_ATTEMPTS:
             time.sleep(NIR_PAIR_RETRY_DELAY_SEC)
-
-    # get IMU and GPS data and save into image EXIF and XMP
-    #add_metadata.add_metadata(image)
-    # no IMU or GPS on the Pi Zero units currently
 
     return None, False
 


### PR DESCRIPTION
## Summary

- Lazily loads `tools/add_metadata.py` via `importlib.util.spec_from_file_location` (explicit file path) and embeds GPS/IMU sensor metadata into each NIR JPEG when the helper and sensors are available
- Adds a clear `Sensor metadata written` success log on each image
- Handles missing dependencies or sensor failures gracefully — capture is never aborted due to metadata errors
- Hardens the metadata-writer initialization so the helper is only marked as available after a successful import

## Copilot review items addressed

All items flagged by Copilot have been resolved in this PR:

- **Metadata write between NIR-OFF and NIR-ON delays the pair / holds capture lock** — fixed: `take_nir_pair()` no longer calls metadata at all; `single_press()` writes metadata after releasing `_capture_lock`, so GPS retry sleeps do not block subsequent button presses.
- **`_metadata_writer_initialized` misleading name** — fixed: renamed to `_metadata_writer_attempted`.
- **Blanket `except` swallowed real errors** — fixed: the redundant outer `try/except Exception: pass` is removed; `_maybe_add_sensor_metadata()` already catches and logs all exceptions internally.
- **sys.path mutation / wrong `tools` package loaded** — fixed: `add_metadata.py` is loaded via `spec_from_file_location` (deterministic, path-based). For its transitive imports (`from tools import bno055_imu`, `from tools.get_gps import ...`), `REPO_ROOT` is temporarily inserted at `sys.path[0]` for the duration of `exec_module`, then sys.path is restored to its exact prior state via `sys.path[:] = _saved_path`.
- **Concurrent `_get_metadata_writer()` races** — fixed: double-checked locking with `_metadata_writer_lock` serializes the init/backoff path.
- **Concurrent `_maybe_add_sensor_metadata()` calls race on GPS/IMU hardware** — fixed: `_metadata_write_lock` serializes all `add_metadata()` calls; gpiozero runs button handlers in worker threads so back-to-back presses could otherwise call into hardware concurrently.
- **`import importlib` unused** — removed; only `importlib.util` is referenced.
- **Dead outer `try/except` in `_get_metadata_writer()`** — removed; the inner try/except already caught everything.
- **`makedirs` TOCTOU in `photos()`** — fixed: `makedirs(exist_ok=True)` replaces the check-then-create pattern.
- **Untyped `pin` in `take_nir_pair` / `button` in `single_press`** — both annotated with their gpiozero types.

## Test plan

- [ ] Deploy to a Pi Zero with sensors attached; confirm `Sensor metadata written` log appears for each NIR JPEG
- [ ] Deploy without sensors (or with sensors disabled); confirm capture completes and logs show graceful skip rather than abort
- [ ] Trigger rapid successive button presses; confirm captures are not delayed by metadata I/O
- [ ] Verify EXIF/XMP data in output JPEGs with `exiftool`

## Related

Splits out camera work from the combined PR #24 (closed). IP transport work is in PR #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)