### PR TITLE
Add IP uplink/downlink transport layer (WiFi/cellular)

### DIFF
--- a/docs/IP_TRANSMISSION.md
+++ b/docs/IP_TRANSMISSION.md
@@ -1,6 +1,6 @@
 # IP Transmission — WaterCam over WiFi/Cellular
 
-**Status:** Client-side implementation complete (standalone). TickTalkPython integration pending.  
+**Status:** Complete — standalone client and TickTalkPython integration both implemented.  
 **Branch:** `CellTransmit`  
 **Last updated:** 2026-04-14
 
@@ -49,8 +49,7 @@ Add or edit the `ip_upload` block:
   "timeout_s": 15,
   "retry_attempts": 3,
   "retry_backoff_s": 2,
-  "fallback_to_lora": true,
-  "downlink_poll_interval_s": 60
+  "fallback_to_lora": true
 }
 ```
 
@@ -62,9 +61,8 @@ Add or edit the `ip_upload` block:
 | `device_id` | str | Logical device identifier used for all uplinks and downlink polling. Must be unique per deployment. |
 | `timeout_s` | int | Per-request timeout in seconds. |
 | `retry_attempts` | int | Max POST attempts before giving up (backoff between attempts). |
-| `retry_backoff_s` | float | Base sleep between retries. Attempt N waits `N * retry_backoff_s` seconds. |
+| `retry_backoff_s` | float | Base sleep between retries. Before attempt N, waits `retry_backoff_s * 2^(N-1)` seconds (exponential backoff). |
 | `fallback_to_lora` | bool | Intent flag for the TickTalkPython integration layer: if IP fails, fall back to LoRa. Not enforced by `transmit_ip.py` itself. |
-| `downlink_poll_interval_s` | int | How often the device should poll for queued commands. |
 
 ---
 

--- a/docs/IP_TRANSMISSION.md
+++ b/docs/IP_TRANSMISSION.md
@@ -175,7 +175,7 @@ The server's `CHANNEL_REGISTRY` maps 2-byte codes to sensor fields.  The
 | `07 27` | `camera_new_local_max` | 4 | uint32 bool |
 | `08 18` | `camera_flood_bitmap` | variable | raw bitmap bytes |
 | `09 19` | `sr_area_threshold_pct` | 4 | uint32 |
-| `09 29` | `sr_stage_threshold_pct` | 4 | uint32 |
+| `09 29` | `sr_stage_threshold_cm` | 4 | uint32 (cm) |
 | `09 39` | `sr_monitoring_frequency` | 4 | uint32 |
 | `09 49` | `sr_emergency_frequency` | 4 | uint32 |
 | `09 59` | `sr_neighborhood_emerg_freq` | 4 | uint32 |

--- a/docs/IP_TRANSMISSION.md
+++ b/docs/IP_TRANSMISSION.md
@@ -390,7 +390,8 @@ calls — zero overhead for LoRa-only deployments.
    on the server side to receive full-resolution JPG/PGM/CSV files.
 2. **Auth** — if the server gains API key auth, populate `api_key` in config and
    update the server to check `Authorization: Bearer <key>` headers.
-3. **GPS decoder bug (server-side)** — the `04 01` GPS channel decodes
-   `gps_lat_raw` / `gps_lon_raw` instead of float lat/lon.  The server
-   `decode_gps_8b` function in `app/decoders.py` needs investigation — it appears
-   to be reading 3 bytes per coordinate instead of 4.
+3. **GPS decoder bug — fixed (API commit 0a63091)** — `decode_gps_8b` in
+   `API/app/decoders.py` had three bugs: 3-byte slices instead of 4-byte,
+   `signed=False` which corrupted W-hemisphere longitudes, and raw integer
+   field names instead of float degrees.  Fixed and covered by `TestGPSDecoder`
+   in `API/tests/test_ip_transport.py`.

--- a/docs/IP_TRANSMISSION.md
+++ b/docs/IP_TRANSMISSION.md
@@ -326,8 +326,10 @@ Two `@SQify` functions have been added to `ticktalk_main.py`:
 
 ### `ip_uplink_transmit(bitmap, sensor_tracker)` (line ~1496)
 
-Collects the same sensor data as `lora_token_with_tracker`, encodes it as
-channel-coded hex, and POSTs to `/ip/uplink`.  Called from `ttmain` immediately
+Collects a subset of sensor data (AHT20 temperature/humidity, GPS, WittyPi
+battery, flood bitmap, flood detect flag, and runtime threshold parameters),
+encodes it as channel-coded hex, and POSTs to `/ip/uplink`.  IMU orientation
+is intentionally omitted (no `03 01` channel).  Called from `ttmain` immediately
 after `lora_return`:
 
 ```python

--- a/docs/IP_TRANSMISSION.md
+++ b/docs/IP_TRANSMISSION.md
@@ -1,0 +1,396 @@
+# IP Transmission — WaterCam over WiFi/Cellular
+
+**Status:** Client-side implementation complete (standalone). TickTalkPython integration pending.  
+**Branch:** `CellTransmit`  
+**Last updated:** 2026-04-14
+
+---
+
+## Overview
+
+The WaterCam device normally sends sensor data over LoRa via an mDot modem.
+On deployments with WiFi or cellular access, the same data can be sent directly
+to the FastAPI server over HTTP.  Both transports produce identical readings in
+InfluxDB and the dashboard — the only difference is the delivery path.
+
+```
+Sensors ──┬── LoRa (mDot → ChirpStack → POST /chirpstack/uplink)
+           └── IP  (requests → POST /ip/uplink)
+                            └── GET /ip/downlink/{device_id}  (polling)
+```
+
+The server auto-sets `transport_type = "ip"` for any device that hits the
+`/ip/uplink` endpoint, which makes the `/downlink` router queue commands
+for polling instead of pushing them through ChirpStack.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `tools/transmit_ip.py` | `IPTransmitter` class — uplink POST and downlink poll |
+| `runtime_config.json` → `ip_upload` | All user-tunable settings |
+| `tests/test_ip_upload.py` | Integration tests against a live server |
+| `docs/IP_TRANSMISSION.md` | This document |
+
+---
+
+## Configuration (`runtime_config.json`)
+
+Add or edit the `ip_upload` block:
+
+```json
+"ip_upload": {
+  "enabled": false,
+  "server_url": "http://localhost:8000",
+  "api_key": "",
+  "device_id": "watercam-001",
+  "timeout_s": 15,
+  "retry_attempts": 3,
+  "retry_backoff_s": 2,
+  "fallback_to_lora": true,
+  "downlink_poll_interval_s": 60
+}
+```
+
+| Key | Type | Description |
+|---|---|---|
+| `enabled` | bool | Master switch. Set `true` to activate IP transport. |
+| `server_url` | str | Base URL of the FastAPI server, no trailing slash. |
+| `api_key` | str | Bearer token for `Authorization` header. Leave empty if the server has no auth. |
+| `device_id` | str | Logical device identifier used for all uplinks and downlink polling. Must be unique per deployment. |
+| `timeout_s` | int | Per-request timeout in seconds. |
+| `retry_attempts` | int | Max POST attempts before giving up (backoff between attempts). |
+| `retry_backoff_s` | float | Base sleep between retries. Attempt N waits `N * retry_backoff_s` seconds. |
+| `fallback_to_lora` | bool | Intent flag for the TickTalkPython integration layer: if IP fails, fall back to LoRa. Not enforced by `transmit_ip.py` itself. |
+| `downlink_poll_interval_s` | int | How often the device should poll for queued commands. |
+
+---
+
+## `IPTransmitter` Class
+
+```python
+from tools.transmit_ip import IPTransmitter
+
+tx = IPTransmitter()  # reads runtime_config.json automatically
+```
+
+### Constructor options
+
+```python
+IPTransmitter(
+    config_path="runtime_config.json",  # path to config
+    override_url="http://...",          # skip config server_url
+    override_device_id="dev-001",       # skip config device_id
+)
+```
+
+### `send_uplink(channels, device_ts=None) → dict`
+
+POST sensor readings to `/ip/uplink`.
+
+**`channels`** — list of channel dicts. Each channel encodes one sensor value:
+
+```python
+channels = [
+    {"code": "00 01", "payload_hex": "000000006710AB12"},  # device timestamp
+    {"code": "02 01", "payload_hex": "00000050"},          # battery 80%
+    {"code": "05 01", "payload_hex": "0898"},              # temperature 22.00°C
+    {"code": "06 01", "payload_hex": "3D"},                # humidity 61%
+    {"code": "04 01", "payload_hex": "028F5C2AFAD47800"},  # GPS lat/lon
+    {"code": "07 17", "payload_hex": "00000001"},          # flood detected
+    {"code": "08 18", "payload_hex": "FF00FF00..."},       # flood bitmap (variable)
+]
+result = tx.send_uplink(channels, device_ts=int(time.time()))
+```
+
+**Returns:**
+```python
+{
+    "success": True,
+    "status_code": 201,
+    "response": { "device_id": "...", "decoded": {...}, "ts": "..." },
+    "error": None,
+    "attempts": 1
+}
+```
+
+On failure `success` is `False` and `error` contains a human-readable message.
+4xx errors are **not retried** (client mistake). 5xx and connection errors are
+retried up to `retry_attempts` times.
+
+### `poll_downlink() → dict`
+
+GET `/ip/downlink/{device_id}` to retrieve the oldest queued command.
+
+```python
+result = tx.poll_downlink()
+if result["success"] and result["command"]:
+    cmd = result["command"]
+    print(cmd["hex_payload"])   # encoded command to decode/apply
+    print(cmd["queue_id"])      # DB id (already marked delivered)
+    print(cmd["parts"])         # decoded parts list (may be None)
+```
+
+The server marks the command as delivered **atomically on retrieval** — there is
+no separate acknowledge call. Once polled, the command is consumed.
+
+**Returns:**
+```python
+{
+    "success": True,
+    "status_code": 200,
+    "command": {                  # or None if nothing queued
+        "queue_id": 42,
+        "hex_payload": "...",
+        "parts": [...],
+        "created_at": "2026-04-14T12:00:00+00:00"
+    },
+    "error": None
+}
+```
+
+### `is_reachable() → bool`
+
+Quickly checks if `/health` responds with HTTP 200. Use this before deciding
+whether to attempt IP or fall back to LoRa.
+
+---
+
+## Channel Encoding Reference
+
+The server's `CHANNEL_REGISTRY` maps 2-byte codes to sensor fields.  The
+`payload_hex` for each channel must be exactly the right length and use
+**big-endian byte order**.
+
+| Code | Field | Bytes | Encoding |
+|---|---|---|---|
+| `00 01` | `device_ts` | 8 | uint64 — UNIX seconds |
+| `01 04` | `emergency_status` | 4 | uint32 bool (0 or 1) |
+| `02 01` | `battery_pct` | 4 | uint32 (0–100) |
+| `03 01` | `imu_block` | 12 | 3× int32 accel (mg), or custom IMU packing |
+| `04 01` | `gps_block` | 8 | int32 lat\_microdeg, int32 lon\_microdeg |
+| `05 01` | `temperature_c` | 2 | int16 (value × 100) |
+| `06 01` | `humidity_pct` | 1 | uint8 (0–100) |
+| `07 17` | `camera_flood_detect` | 4 | uint32 bool |
+| `07 27` | `camera_new_local_max` | 4 | uint32 bool |
+| `08 18` | `camera_flood_bitmap` | variable | raw bitmap bytes |
+| `09 19` | `sr_area_threshold_pct` | 4 | uint32 |
+| `09 29` | `sr_stage_threshold_pct` | 4 | uint32 |
+| `09 39` | `sr_monitoring_frequency` | 4 | uint32 |
+| `09 49` | `sr_emergency_frequency` | 4 | uint32 |
+| `09 59` | `sr_neighborhood_emerg_freq` | 4 | uint32 |
+
+**Encoding examples (Python `struct`):**
+
+```python
+import struct, time
+
+# device_ts — 8 bytes
+struct.pack(">Q", int(time.time())).hex()
+
+# battery_pct — 4 bytes
+struct.pack(">I", 75).hex()          # → "0000004b"
+
+# temperature_c — 2 bytes (22.50°C → 2250 → 0x08CA)
+struct.pack(">h", int(22.50 * 100)).hex()
+
+# humidity_pct — 1 byte
+struct.pack(">B", 61).hex()          # → "3d"
+
+# gps_block — 8 bytes (43.0389°N, -76.1322°W)
+struct.pack(">ii", int(43.0389 * 1e6), int(-76.1322 * 1e6)).hex()
+
+# flood bitmap — variable
+bitmap_bytes = b'\xff\x00\xff\x00'   # 8 pixels, alternating
+bitmap_bytes.hex()
+```
+
+---
+
+## Server API Endpoints
+
+All endpoints are on the FastAPI server (`../API`).  
+Base path: `{server_url}/` (no version prefix currently).
+
+### `POST /ip/uplink`
+
+Receive sensor data from an IP device.
+
+**Request body:**
+```json
+{
+    "device_id": "watercam-001",
+    "device_ts": 1712000000,
+    "channels": [
+        {"code": "02 01", "payload_hex": "00000050"},
+        {"code": "05 01", "payload_hex": "0898"}
+    ]
+}
+```
+
+- `device_ts` — optional; if omitted, server time is used.
+- `channels` — at least one required (or provide `payload_hex` for raw TTLoRa hex).
+- Side effect: device `transport_type` is set to `"ip"` on first call.
+
+**Response (201):**
+```json
+{
+    "device_id": "watercam-001",
+    "channel": "multi",
+    "ts": "2026-04-14T12:00:00+00:00",
+    "decoded": {
+        "battery_pct": { "value": 80, "unit": "%" },
+        "temperature_c": { "value": 22.0, "unit": "°C" }
+    }
+}
+```
+
+### `GET /ip/downlink/{device_id}`
+
+Poll for the oldest pending queued command.
+
+**Response (200) — command pending:**
+```json
+{
+    "command": {
+        "queue_id": 42,
+        "hex_payload": "09192A...",
+        "parts": [...],
+        "created_at": "2026-04-14T11:55:00+00:00"
+    },
+    "message": "Command retrieved successfully"
+}
+```
+
+**Response (200) — nothing queued:**
+```json
+{"command": null, "message": "No pending commands"}
+```
+
+The command is marked delivered **atomically** when retrieved. No ACK needed.
+
+### `POST /ip/device/{device_id}/transport`
+
+Manually set the transport type for a device.
+
+```json
+{"transport_type": "ip"}
+```
+
+Usually not needed — `/ip/uplink` sets `transport_type = "ip"` automatically.
+
+---
+
+## Running the Tests
+
+```bash
+# From the project root:
+python tests/test_ip_upload.py
+
+# Or with pytest:
+pytest tests/test_ip_upload.py -v
+
+# Point at a different server:
+WATERCAM_SERVER_URL=http://192.168.1.50:8000 python tests/test_ip_upload.py
+
+# Use a different device ID (avoids polluting production data):
+WATERCAM_DEVICE_ID=test-device-ci python tests/test_ip_upload.py
+```
+
+The tests **skip** (rather than fail) if the server is unreachable, so they are
+safe to include in CI pipelines where the API may not be running.
+
+Tests that create real readings in InfluxDB/SQLite — the `device_id` used during
+testing will appear in the dashboard.  Use `WATERCAM_DEVICE_ID=...` to isolate
+test traffic from production devices.
+
+---
+
+## Smoke-Testing the Transmitter Directly
+
+```bash
+python tools/transmit_ip.py
+```
+
+This encodes a minimal uplink (timestamp + battery + temperature) using values
+from the script's `__main__` block and prints the server's response.  The server
+URL and device ID come from `runtime_config.json`.
+
+---
+
+## TickTalkPython Integration
+
+**Status: Complete** as of 2026-04-14.
+
+Two `@SQify` functions have been added to `ticktalk_main.py`:
+
+### `ip_uplink_transmit(bitmap, sensor_tracker)` (line ~1496)
+
+Collects the same sensor data as `lora_token_with_tracker`, encodes it as
+channel-coded hex, and POSTs to `/ip/uplink`.  Called from `ttmain` immediately
+after `lora_return`:
+
+```python
+lora_return = lora_token_with_tracker(bitmap, sensor_tracker)  # existing
+ip_return   = ip_uplink_transmit(bitmap, sensor_tracker)       # NEW — parallel
+```
+
+Both branches receive the same `bitmap` and `sensor_tracker` inputs and run
+independently.  A failure in IP never affects LoRa and vice versa.
+
+**Sensor data collected:**
+- AHT20: `temperature_celsius` → channel `05 01`, `relative_humidity` → `06 01`
+- GPS: `gps_lat` / `gps_lon` → channel `04 01`
+- WittyPi: `battery_voltage` converted to % → channel `02 01`
+- Bitmap: contents → channel `08 18`; flood detect flag → channel `07 17`
+- Runtime params: area/stage thresholds, frequencies → channels `09 19`–`09 59`
+
+**Reachability check:** `is_reachable()` is called before encoding; if the
+server doesn't respond, the function returns `{"status": "unreachable"}` without
+spending time on encoding.
+
+### `ip_downlink_poll_and_apply(lora_init)` (line ~1647)
+
+Polls `/ip/downlink/{device_id}` once per wake cycle and applies any queued
+parameter-update commands.  Called after `initialize_lora_integration` so
+updated thresholds are in effect for the capture cycle that follows:
+
+```python
+lora_init   = initialize_lora_integration(trigger)
+ip_downlink = ip_downlink_poll_and_apply(lora_init)  # NEW
+```
+
+**Downlink command codes handled** (from server `app/encoders.py`):
+
+| Code | Name | Decoding | `set_parameter` target |
+|---|---|---|---|
+| `10 90` | `area_threshold_pct` | u8 direct | `area_threshold` |
+| `11 91` | `stage_threshold_cm` | u16 direct | `stage_threshold` |
+| `12 92` | `monitoring_freq_h` | u8 index → `[1,3,6,24,72]` hrs → ×60 | `monitoring_frequency` (min) |
+| `13 93` | `emergency_freq_min` | u8 index → `[2,5,10]` min | `emergency_frequency` |
+| `14 94` | `flood_code_freq_min` | u8 index → `[10,20,30,40,50,60]` min | `neighborhood_emergency_frequency` |
+
+Unrecognised codes are logged and ignored — forward-compatible with new server
+commands.
+
+### Enabling IP in the main application
+
+Set `ip_upload.enabled = true` in `runtime_config.json`.  When disabled (the
+default), both `@SQify` functions return immediately without making any network
+calls — zero overhead for LoRa-only deployments.
+
+---
+
+## Known Gaps / Next Steps
+
+1. **Full image upload** — the current `/ip/uplink` channel scheme only carries
+   the compressed bitmap.  A separate `POST /ip/image` endpoint would be needed
+   on the server side to receive full-resolution JPG/PGM/CSV files.
+2. **Auth** — if the server gains API key auth, populate `api_key` in config and
+   update the server to check `Authorization: Bearer <key>` headers.
+3. **GPS decoder bug (server-side)** — the `04 01` GPS channel decodes
+   `gps_lat_raw` / `gps_lon_raw` instead of float lat/lon.  The server
+   `decode_gps_8b` function in `app/decoders.py` needs investigation — it appears
+   to be reading 3 bytes per coordinate instead of 4.

--- a/runtime_config.example.json
+++ b/runtime_config.example.json
@@ -1,0 +1,28 @@
+{
+  "area_threshold": 10,
+  "stage_threshold": 50,
+  "monitoring_frequency": 60,
+  "emergency_frequency": 5,
+  "photo_interval": 60,
+  "neighborhood_emergency_frequency": 30,
+  "emergency_mode": false,
+  "debug_mode": false,
+
+  "max_retransmissions": 3,
+  "auto_shutdown_enabled": true,
+  "shutdown_iteration_limit": 3,
+  "data_retention_days": 7,
+  "backup_enabled": true,
+
+  "ip_upload": {
+    "enabled": false,
+    "server_url": "http://<server-hostname>:8000",
+    "api_key": "",
+    "device_id": "watercam-001",
+    "timeout_s": 15,
+    "retry_attempts": 3,
+    "retry_backoff_s": 2,
+    "fallback_to_lora": true,
+    "downlink_poll_interval_s": 60
+  }
+}

--- a/runtime_config.example.json
+++ b/runtime_config.example.json
@@ -7,6 +7,7 @@
   "neighborhood_emergency_frequency": 30,
   "emergency_mode": false,
   "debug_mode": false,
+  "always_transmit_sensors": false,
 
   "max_retransmissions": 3,
   "auto_shutdown_enabled": true,
@@ -22,7 +23,6 @@
     "timeout_s": 15,
     "retry_attempts": 3,
     "retry_backoff_s": 2,
-    "fallback_to_lora": true,
-    "downlink_poll_interval_s": 60
+    "fallback_to_lora": true
   }
 }

--- a/tests/test_ip_upload.py
+++ b/tests/test_ip_upload.py
@@ -112,6 +112,12 @@ class TestIPUplink(unittest.TestCase):
             )
         print(f"\nServer: {cls.tx.server_url}  Device: {cls.tx.device_id}")
 
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "tx", None) is not None:
+            cls.tx.close()
+            cls.tx = None
+
     def test_01_minimal_uplink_battery_and_temperature(self):
         """Simplest valid uplink: battery + temperature."""
         ts = int(time.time())
@@ -228,6 +234,12 @@ class TestIPDownlink(unittest.TestCase):
                 f"Server not reachable at {cls.tx.server_url} — start the API first."
             )
 
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "tx", None) is not None:
+            cls.tx.close()
+            cls.tx = None
+
     def test_01_poll_returns_valid_structure(self):
         """Polling with no pending command returns a well-formed response."""
         result = self.tx.poll_downlink()
@@ -251,7 +263,10 @@ class TestIPDownlink(unittest.TestCase):
             override_url=self.tx.server_url,
             override_device_id="__nonexistent_test_device__",
         )
-        result = tx2.poll_downlink()
+        try:
+            result = tx2.poll_downlink()
+        finally:
+            tx2.close()
         # May return 200 {"command": null} or 404 depending on API version
         self.assertIn(result["status_code"], (200, 404))
         self.assertIsNone(result.get("command"))
@@ -263,7 +278,10 @@ class TestIPReachability(unittest.TestCase):
     def test_is_reachable_live_server(self):
         """is_reachable() should return True when server is up."""
         tx = _make_transmitter()
-        reachable = tx.is_reachable()
+        try:
+            reachable = tx.is_reachable()
+        finally:
+            tx.close()
         if not reachable:
             self.skipTest(f"Server not reachable at {tx.server_url}")
         self.assertTrue(reachable)
@@ -271,7 +289,11 @@ class TestIPReachability(unittest.TestCase):
     def test_is_reachable_bad_url(self):
         """is_reachable() should return False for a definitely-wrong URL."""
         tx = IPTransmitter(override_url="http://127.0.0.1:19999")
-        self.assertFalse(tx.is_reachable())
+        try:
+            result = tx.is_reachable()
+        finally:
+            tx.close()
+        self.assertFalse(result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ip_upload.py
+++ b/tests/test_ip_upload.py
@@ -102,7 +102,10 @@ class TestIPUplink(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tx = _make_transmitter()
-        if not cls.tx.is_reachable():
+        # Use a short timeout for the health check so CI skips quickly when the
+        # server is not running — the full timeout_s (default 15 s) would add
+        # significant delay per test class before the skip is issued.
+        if not cls.tx.is_reachable(timeout_s=3):
             raise unittest.SkipTest(
                 f"Server not reachable at {cls.tx.server_url} — start the API first "
                 "or set WATERCAM_SERVER_URL to point at a running instance."
@@ -220,7 +223,7 @@ class TestIPDownlink(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tx = _make_transmitter()
-        if not cls.tx.is_reachable():
+        if not cls.tx.is_reachable(timeout_s=3):
             raise unittest.SkipTest(
                 f"Server not reachable at {cls.tx.server_url} — start the API first."
             )

--- a/tests/test_ip_upload.py
+++ b/tests/test_ip_upload.py
@@ -1,0 +1,279 @@
+"""Integration tests for IP uplink/downlink transport.
+
+Runs against a live WaterCam FastAPI server.  The server URL and device ID
+are read from runtime_config.json (ip_upload section) and can be overridden
+via environment variables:
+
+    WATERCAM_SERVER_URL=http://localhost:8000
+    WATERCAM_DEVICE_ID=watercam-test-001
+
+These tests are NOT unit tests — they require the API to be running.
+They will skip cleanly if the server is unreachable rather than failing.
+
+Run with:
+    python tests/test_ip_upload.py
+or (if pytest is available):
+    pytest tests/test_ip_upload.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import time
+import unittest
+
+# Allow running from project root or from tests/
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from tools.transmit_ip import IPTransmitter, _DEFAULT_CONFIG_PATH
+
+# ---------------------------------------------------------------------------
+# Config — override via env vars for CI / deployment testing
+# ---------------------------------------------------------------------------
+
+_SERVER_URL = os.environ.get("WATERCAM_SERVER_URL") or None
+_DEVICE_ID = os.environ.get("WATERCAM_DEVICE_ID") or None
+
+
+def _make_transmitter() -> IPTransmitter:
+    """Build a transmitter, applying env-var overrides if set."""
+    return IPTransmitter(
+        config_path=_DEFAULT_CONFIG_PATH,
+        override_url=_SERVER_URL,
+        override_device_id=_DEVICE_ID,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Channel encoding helpers (mirrors what the main application will produce)
+# ---------------------------------------------------------------------------
+
+def encode_device_ts(ts: int) -> dict:
+    """00 01 — UNIX seconds as unsigned 64-bit big-endian."""
+    return {"code": "00 01", "payload_hex": struct.pack(">Q", ts).hex()}
+
+
+def encode_battery(pct: int) -> dict:
+    """02 01 — battery percent as uint32 big-endian."""
+    return {"code": "02 01", "payload_hex": struct.pack(">I", pct).hex()}
+
+
+def encode_temperature(temp_c: float) -> dict:
+    """05 01 — temperature as int16 (value * 100), big-endian."""
+    raw = int(round(temp_c * 100))
+    return {"code": "05 01", "payload_hex": struct.pack(">h", raw).hex()}
+
+
+def encode_humidity(pct: int) -> dict:
+    """06 01 — humidity as uint8."""
+    return {"code": "06 01", "payload_hex": struct.pack(">B", pct).hex()}
+
+
+def encode_gps(lat: float, lon: float) -> dict:
+    """04 01 — GPS as two int32 values (degrees * 1e6), big-endian."""
+    lat_raw = int(round(lat * 1_000_000))
+    lon_raw = int(round(lon * 1_000_000))
+    return {"code": "04 01", "payload_hex": struct.pack(">ii", lat_raw, lon_raw).hex()}
+
+
+def encode_flood_detect(detected: bool) -> dict:
+    """07 17 — camera flood detect as uint32 bool."""
+    return {"code": "07 17", "payload_hex": struct.pack(">I", int(detected)).hex()}
+
+
+def encode_flood_bitmap(bitmap_bytes: bytes) -> dict:
+    """08 18 — variable-length flood bitmap."""
+    return {"code": "08 18", "payload_hex": bitmap_bytes.hex()}
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestIPUplink(unittest.TestCase):
+    """Tests for POST /ip/uplink."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tx = _make_transmitter()
+        if not cls.tx.is_reachable():
+            raise unittest.SkipTest(
+                f"Server not reachable at {cls.tx.server_url} — start the API first "
+                "or set WATERCAM_SERVER_URL to point at a running instance."
+            )
+        print(f"\nServer: {cls.tx.server_url}  Device: {cls.tx.device_id}")
+
+    def test_01_minimal_uplink_battery_and_temperature(self):
+        """Simplest valid uplink: battery + temperature."""
+        ts = int(time.time())
+        channels = [
+            encode_device_ts(ts),
+            encode_battery(80),
+            encode_temperature(21.5),
+        ]
+        result = self.tx.send_uplink(channels, device_ts=ts)
+
+        self.assertTrue(result["success"], f"Upload failed: {result.get('error')}")
+        self.assertIn(result["status_code"], (200, 201))
+        resp = result["response"]
+        self.assertIn("device_id", resp)
+        self.assertIn("decoded", resp)
+        decoded = resp["decoded"]
+        self.assertIn("battery_pct", decoded)
+        self.assertIn("temperature_c", decoded)
+        print(f"  decoded: {json.dumps(decoded, indent=4)}")
+
+    def test_02_full_sensor_uplink(self):
+        """Uplink with all standard sensor channels."""
+        ts = int(time.time())
+        # Syracuse University coordinates (test fixture)
+        channels = [
+            encode_device_ts(ts),
+            encode_battery(65),
+            encode_temperature(18.75),
+            encode_humidity(62),
+            encode_gps(43.0389, -76.1322),
+        ]
+        result = self.tx.send_uplink(channels, device_ts=ts)
+
+        self.assertTrue(result["success"], f"Upload failed: {result.get('error')}")
+        decoded = result["response"]["decoded"]
+        self.assertIn("battery_pct", decoded)
+        self.assertIn("temperature_c", decoded)
+        self.assertIn("humidity_pct", decoded)
+        self.assertIn("gps_block", decoded)
+        print(f"  GPS decoded: {decoded.get('gps_block')}")
+
+    def test_03_uplink_with_flood_detect(self):
+        """Uplink including camera flood detect flag."""
+        ts = int(time.time())
+        channels = [
+            encode_device_ts(ts),
+            encode_battery(55),
+            encode_flood_detect(True),
+        ]
+        result = self.tx.send_uplink(channels, device_ts=ts)
+
+        self.assertTrue(result["success"], f"Upload failed: {result.get('error')}")
+        decoded = result["response"]["decoded"]
+        self.assertIn("camera_flood_detect", decoded)
+        print(f"  flood_detect: {decoded.get('camera_flood_detect')}")
+
+    def test_04_uplink_with_bitmap(self):
+        """Uplink with a small synthetic flood bitmap (variable-length channel)."""
+        ts = int(time.time())
+        # 8x8 bitmap, alternating bytes as a synthetic flood mask
+        bitmap = bytes([0xFF, 0x00] * 4)
+        channels = [
+            encode_device_ts(ts),
+            encode_battery(50),
+            encode_flood_bitmap(bitmap),
+        ]
+        result = self.tx.send_uplink(channels, device_ts=ts)
+
+        self.assertTrue(result["success"], f"Upload failed: {result.get('error')}")
+        decoded = result["response"]["decoded"]
+        self.assertIn("camera_flood_bitmap", decoded)
+        print(f"  bitmap decoded: {decoded.get('camera_flood_bitmap')}")
+
+    def test_05_uplink_device_ts_precision(self):
+        """Verify device timestamp is respected by the server."""
+        # Use a fixed past timestamp so we can confirm it is echoed back
+        fixed_ts = 1_700_000_000  # Nov 14 2023
+        channels = [
+            encode_device_ts(fixed_ts),
+            encode_battery(90),
+        ]
+        result = self.tx.send_uplink(channels, device_ts=fixed_ts)
+
+        self.assertTrue(result["success"], f"Upload failed: {result.get('error')}")
+        resp_ts = result["response"].get("ts", "")
+        # Server should echo back a timestamp near the device timestamp
+        print(f"  response ts: {resp_ts}")
+        self.assertIn("2023", resp_ts, "Server should reflect the device timestamp year")
+
+    def test_06_uplink_empty_channels_rejected(self):
+        """Empty channels list should fail locally before hitting the server."""
+        result = self.tx.send_uplink([])
+        self.assertFalse(result["success"])
+        self.assertIsNotNone(result["error"])
+
+    def test_07_multiple_uplinks_idempotency(self):
+        """Sending the same data twice should succeed both times."""
+        ts = int(time.time())
+        channels = [encode_battery(70), encode_temperature(20.0)]
+        r1 = self.tx.send_uplink(channels, device_ts=ts)
+        r2 = self.tx.send_uplink(channels, device_ts=ts)
+        self.assertTrue(r1["success"], f"First upload failed: {r1.get('error')}")
+        self.assertTrue(r2["success"], f"Second upload failed: {r2.get('error')}")
+
+
+class TestIPDownlink(unittest.TestCase):
+    """Tests for GET /ip/downlink/{device_id}."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tx = _make_transmitter()
+        if not cls.tx.is_reachable():
+            raise unittest.SkipTest(
+                f"Server not reachable at {cls.tx.server_url} — start the API first."
+            )
+
+    def test_01_poll_returns_valid_structure(self):
+        """Polling with no pending command returns a well-formed response."""
+        result = self.tx.poll_downlink()
+
+        self.assertTrue(result["success"], f"Poll failed: {result.get('error')}")
+        self.assertEqual(result["status_code"], 200)
+        # command is either None (no pending) or a dict
+        self.assertIn("command", result)
+        cmd = result["command"]
+        if cmd is not None:
+            self.assertIn("hex_payload", cmd)
+            self.assertIn("queue_id", cmd)
+            print(f"  Received pending command: {cmd}")
+        else:
+            print("  No pending commands (expected if queue is empty)")
+
+    def test_02_poll_does_not_crash_on_unknown_device(self):
+        """Polling for a never-seen device should return 200 with no command."""
+        tx2 = IPTransmitter(
+            config_path=_DEFAULT_CONFIG_PATH,
+            override_url=self.tx.server_url,
+            override_device_id="__nonexistent_test_device__",
+        )
+        result = tx2.poll_downlink()
+        # May return 200 {"command": null} or 404 depending on API version
+        self.assertIn(result["status_code"], (200, 404))
+        self.assertIsNone(result.get("command"))
+
+
+class TestIPReachability(unittest.TestCase):
+    """Basic connectivity checks."""
+
+    def test_is_reachable_live_server(self):
+        """is_reachable() should return True when server is up."""
+        tx = _make_transmitter()
+        reachable = tx.is_reachable()
+        if not reachable:
+            self.skipTest(f"Server not reachable at {tx.server_url}")
+        self.assertTrue(reachable)
+
+    def test_is_reachable_bad_url(self):
+        """is_reachable() should return False for a definitely-wrong URL."""
+        tx = IPTransmitter(override_url="http://127.0.0.1:19999")
+        self.assertFalse(tx.is_reachable())
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_ip_upload.py
+++ b/tests/test_ip_upload.py
@@ -106,8 +106,11 @@ class TestIPUplink(unittest.TestCase):
         # server is not running — the full timeout_s (default 15 s) would add
         # significant delay per test class before the skip is issued.
         if not cls.tx.is_reachable(timeout_s=3):
+            server_url = cls.tx.server_url
+            cls.tx.close()
+            cls.tx = None
             raise unittest.SkipTest(
-                f"Server not reachable at {cls.tx.server_url} — start the API first "
+                f"Server not reachable at {server_url} — start the API first "
                 "or set WATERCAM_SERVER_URL to point at a running instance."
             )
         print(f"\nServer: {cls.tx.server_url}  Device: {cls.tx.device_id}")
@@ -230,8 +233,11 @@ class TestIPDownlink(unittest.TestCase):
     def setUpClass(cls):
         cls.tx = _make_transmitter()
         if not cls.tx.is_reachable(timeout_s=3):
+            server_url = cls.tx.server_url
+            cls.tx.close()
+            cls.tx = None
             raise unittest.SkipTest(
-                f"Server not reachable at {cls.tx.server_url} — start the API first."
+                f"Server not reachable at {server_url} — start the API first."
             )
 
     @classmethod

--- a/tests/test_ip_upload.py
+++ b/tests/test_ip_upload.py
@@ -245,7 +245,8 @@ class TestIPDownlink(unittest.TestCase):
         result = self.tx.poll_downlink()
 
         self.assertTrue(result["success"], f"Poll failed: {result.get('error')}")
-        self.assertEqual(result["status_code"], 200)
+        # poll_downlink treats 404 (device not yet registered) as success + no command
+        self.assertIn(result["status_code"], (200, 404))
         # command is either None (no pending) or a dict
         self.assertIn("command", result)
         cmd = result["command"]

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -272,9 +272,12 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
         'neighborhood_emergency_frequency': get_parameter('neighborhood_emergency_frequency', 30)
     })
 
-    # Check sensor changes using tracker if available
+    # Check sensor changes using tracker if available (unless always_transmit_sensors is set)
+    always_transmit_sensors = get_parameter('always_transmit_sensors', False)
+    if always_transmit_sensors:
+        print(f"📡 always_transmit_sensors=True: bypassing sensor change check")
     sensors_to_transmit = {}
-    if sensor_tracker:
+    if sensor_tracker and not always_transmit_sensors:
         try:
             # Call check_sensor_changes directly since it's in the same module
             sensors_to_transmit = check_sensor_changes(sensor_tracker, data)
@@ -290,10 +293,10 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
         print(f"⚠️ Failed to get LoRa handler: {e}")
         return bitmap
 
-    # Transmit sensor data only if changes detected or no tracker available
+    # Transmit sensor data if: no tracker, always_transmit_sensors, or changes detected
     transmission_result = {'transmitted_sensors': [], 'change_percent': {}}
     
-    if not sensor_tracker or sensors_to_transmit:
+    if always_transmit_sensors or not sensor_tracker or sensors_to_transmit:
         try:
             # Filter data to only include sensors that changed significantly
             if sensor_tracker and sensors_to_transmit:
@@ -304,7 +307,7 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
             else:
                 filtered_data = data
                 transmission_result['transmitted_sensors'] = list(data.keys())
-                print(f"📡 Transmitting all sensor data (no tracker or all sensors qualify)")
+                print(f"📡 Transmitting all sensor data (no tracker, always_transmit_sensors, or all sensors qualify)")
             
             handler.queue_transmit(filtered_data)
             handler.process_transmit_queue()
@@ -1490,6 +1493,269 @@ def log_sensor_tracking_stats(sensor_tracker):
         print(f"⚠️ Failed to log sensor tracking stats: {e}")
         return {'status': 'error', 'error': str(e)}
 
+@SQify
+def ip_uplink_transmit(bitmap, sensor_tracker):
+    """Send sensor readings and flood bitmap to the FastAPI server over IP (WiFi/cellular).
+
+    Collects the same sensor data as lora_token_with_tracker, encodes it as
+    channel-coded hex blocks (same format the API already understands for LoRa
+    uplinks), and POSTs to /ip/uplink.
+
+    Disabled by default — set ip_upload.enabled=true in runtime_config.json to
+    activate.  When fallback_to_lora=true and IP fails, the data has already been
+    sent via LoRa so nothing is lost.
+
+    Returns a status dict (never raises) so a failure here never stops the main
+    workflow.
+    """
+    import struct
+    import time as _time
+    from tools.transmit_ip import IPTransmitter
+    from tools.lora_runtime_integration import get_parameter
+
+    tx = IPTransmitter()
+
+    if not tx.enabled:
+        print("📡 IP uplink disabled (ip_upload.enabled=false) — skipping")
+        return {"status": "disabled", "success": False}
+
+    if not tx.is_reachable():
+        print(f"⚠️ IP uplink: server unreachable at {tx.server_url}")
+        return {"status": "unreachable", "success": False}
+
+    # ── Collect sensor data ────────────────────────────────────────────────────
+    data = {}
+
+    try:
+        from tools.bno055_imu import get_orientation
+        data.update(get_orientation())
+    except Exception as e:
+        print(f"⚠️ IP uplink: IMU unavailable: {e}")
+
+    try:
+        from tools.aht20_temperature import get_aht20
+        data.update(get_aht20())
+    except Exception as e:
+        print(f"⚠️ IP uplink: AHT20 unavailable: {e}")
+
+    try:
+        from tools.get_gps import get_location_with_retry
+        gps, _ = get_location_with_retry()
+        if gps:
+            data.update(gps)
+    except Exception as e:
+        print(f"⚠️ IP uplink: GPS unavailable: {e}")
+
+    try:
+        from tools.wittypi_control import get_wittypi_status
+        wittypi_data = get_wittypi_status()
+        if wittypi_data.get('status') == 'wittypi_data_retrieved':
+            data['wittypi_battery_voltage'] = wittypi_data.get('battery_voltage', 0.0)
+    except Exception as e:
+        print(f"⚠️ IP uplink: WittyPi unavailable: {e}")
+
+    data['area_threshold']                    = get_parameter('area_threshold', 10)
+    data['stage_threshold']                   = get_parameter('stage_threshold', 50)
+    data['monitoring_frequency']              = get_parameter('monitoring_frequency', 60)
+    data['emergency_frequency']               = get_parameter('emergency_frequency', 5)
+    data['neighborhood_emergency_frequency']  = get_parameter('neighborhood_emergency_frequency', 30)
+
+    # ── Build channel list ─────────────────────────────────────────────────────
+    channels = []
+    ts_now = int(_time.time())
+
+    # 00 01 — device timestamp (8-byte uint64)
+    channels.append({"code": "00 01", "payload_hex": struct.pack(">Q", ts_now).hex()})
+
+    # 02 01 — battery percent derived from WittyPi voltage (LiPo: 3.0V=0%, 4.2V=100%)
+    batt_v = data.get('wittypi_battery_voltage', 0.0)
+    if batt_v and batt_v > 0:
+        batt_pct = max(0, min(100, int((batt_v - 3.0) / 1.2 * 100)))
+        channels.append({"code": "02 01", "payload_hex": struct.pack(">I", batt_pct).hex()})
+
+    # 04 01 — GPS block (lat int32 microdeg, lon int32 microdeg)
+    lat = data.get('gps_lat')
+    lon = data.get('gps_lon')
+    if lat is not None and lon is not None:
+        try:
+            channels.append({
+                "code": "04 01",
+                "payload_hex": struct.pack(">ii",
+                    int(round(lat * 1_000_000)),
+                    int(round(lon * 1_000_000)),
+                ).hex(),
+            })
+        except struct.error as e:
+            print(f"⚠️ IP uplink: GPS encoding error (lat={lat}, lon={lon}): {e}")
+
+    # 05 01 — temperature (int16, value × 100)
+    temp = data.get('temperature_celsius')
+    if temp is not None:
+        try:
+            channels.append({"code": "05 01",
+                              "payload_hex": struct.pack(">h", int(round(temp * 100))).hex()})
+        except struct.error as e:
+            print(f"⚠️ IP uplink: temperature encoding error (temp={temp}): {e}")
+
+    # 06 01 — humidity (uint8)
+    hum = data.get('relative_humidity')
+    if hum is not None:
+        channels.append({"code": "06 01",
+                         "payload_hex": struct.pack(">B", max(0, min(255, int(hum)))).hex()})
+
+    # 07 17 — flood detect (inferred from bitmap content)
+    flood_detected = bool(bitmap and any(b != 0 for b in bitmap))
+    channels.append({"code": "07 17",
+                     "payload_hex": struct.pack(">I", int(flood_detected)).hex()})
+
+    # 08 18 — flood bitmap (variable length, only if non-empty)
+    if bitmap:
+        channels.append({"code": "08 18", "payload_hex": bytes(bitmap).hex()})
+
+    # 09 xx — status reports
+    channels.append({"code": "09 19",
+                     "payload_hex": struct.pack(">I", int(data['area_threshold'])).hex()})
+    channels.append({"code": "09 29",
+                     "payload_hex": struct.pack(">I", int(data['stage_threshold'])).hex()})
+    channels.append({"code": "09 39",
+                     "payload_hex": struct.pack(">I", int(data['monitoring_frequency'])).hex()})
+    channels.append({"code": "09 49",
+                     "payload_hex": struct.pack(">I", int(data['emergency_frequency'])).hex()})
+    channels.append({"code": "09 59",
+                     "payload_hex": struct.pack(">I",
+                         int(data['neighborhood_emergency_frequency'])).hex()})
+
+    # ── Transmit ───────────────────────────────────────────────────────────────
+    result = tx.send_uplink(channels, device_ts=ts_now)
+
+    if result["success"]:
+        print(f"✅ IP uplink OK: {len(channels)} channels sent "
+              f"(attempt {result.get('attempts', '?')})")
+    else:
+        print(f"⚠️ IP uplink failed after {result.get('attempts', '?')} attempt(s): "
+              f"{result.get('error', 'unknown error')}")
+        if tx.fallback_to_lora:
+            print("📡 LoRa fallback is enabled — data already sent via LoRa path")
+
+    return {
+        "status": "ok" if result["success"] else "failed",
+        "channels_sent": len(channels),
+        "result": result,
+    }
+
+
+@SQify
+def ip_downlink_poll_and_apply(lora_init):
+    """Poll /ip/downlink/{device_id} for queued server commands and apply them.
+
+    The server queues parameter-update commands when a human operator (or weather
+    automation) sends a downlink via the dashboard.  This function retrieves the
+    oldest pending command, decodes the parts list, and applies each recognised
+    parameter change to the runtime config via set_parameter().
+
+    Runs once at the start of each wake cycle (after LoRa init) so the device
+    picks up any commands that arrived while it was sleeping.
+
+    Disabled by default — requires ip_upload.enabled=true in runtime_config.json.
+    """
+    from tools.transmit_ip import IPTransmitter
+    from tools.lora_runtime_integration import set_parameter
+
+    tx = IPTransmitter()
+
+    if not tx.enabled:
+        return {"status": "disabled"}
+
+    poll_result = tx.poll_downlink()
+
+    if not poll_result["success"]:
+        print(f"⚠️ IP downlink poll failed: {poll_result.get('error')}")
+        return {"status": "poll_failed", "error": poll_result.get("error")}
+
+    cmd = poll_result.get("command")
+    if not cmd:
+        print("📬 IP downlink: no pending commands")
+        return {"status": "no_command"}
+
+    print(f"📬 IP downlink: received command (queue_id={cmd.get('queue_id')})")
+
+    parts = cmd.get("parts") or []
+    applied = []
+
+    # Index-based lookup tables — must match server app/encoders.py constants
+    _MF_HOURS = [1, 3, 6, 24, 72]    # monitoring_freq_h allowed values
+    _EF_MIN   = [2, 5, 10]           # emergency_freq_min allowed values
+    _FF_MIN   = [10, 20, 30, 40, 50, 60]  # flood_code_freq_min allowed values
+
+    for part in parts:
+        code        = part.get("code", "").strip()
+        payload_hex = part.get("payload_hex", "")
+
+        try:
+            payload_bytes = bytes.fromhex(payload_hex)
+        except ValueError:
+            print(f"⚠️ IP downlink: bad payload_hex in part {part} — skipping")
+            continue
+
+        if code == "10 90":  # area_threshold_pct — direct u8 value
+            val = int.from_bytes(payload_bytes, 'big')
+            set_parameter('area_threshold', val)
+            print(f"⬇️ Applied: area_threshold = {val}%")
+            applied.append(f"area_threshold={val}%")
+
+        elif code == "11 91":  # stage_threshold_cm — u16, stored as cm
+            val_cm = int.from_bytes(payload_bytes, 'big')
+            set_parameter('stage_threshold', val_cm)
+            print(f"⬇️ Applied: stage_threshold = {val_cm}cm")
+            applied.append(f"stage_threshold={val_cm}cm")
+
+        elif code == "12 92":  # monitoring_freq_h — u8 index into _MF_HOURS
+            idx = int.from_bytes(payload_bytes, 'big')
+            if 0 <= idx < len(_MF_HOURS):
+                hours = _MF_HOURS[idx]
+                set_parameter('monitoring_frequency', hours * 60)  # stored in minutes
+                print(f"⬇️ Applied: monitoring_frequency = {hours}h ({hours * 60}min)")
+                applied.append(f"monitoring_frequency={hours}h")
+            else:
+                print(f"⚠️ IP downlink: monitoring_freq index {idx} out of range")
+
+        elif code == "13 93":  # emergency_freq_min — u8 index into _EF_MIN
+            idx = int.from_bytes(payload_bytes, 'big')
+            if 0 <= idx < len(_EF_MIN):
+                mins = _EF_MIN[idx]
+                set_parameter('emergency_frequency', mins)
+                print(f"⬇️ Applied: emergency_frequency = {mins}min")
+                applied.append(f"emergency_frequency={mins}min")
+            else:
+                print(f"⚠️ IP downlink: emergency_freq index {idx} out of range")
+
+        elif code == "14 94":  # flood_code_freq_min — u8 index into _FF_MIN
+            idx = int.from_bytes(payload_bytes, 'big')
+            if 0 <= idx < len(_FF_MIN):
+                mins = _FF_MIN[idx]
+                set_parameter('neighborhood_emergency_frequency', mins)
+                print(f"⬇️ Applied: neighborhood_emergency_frequency = {mins}min")
+                applied.append(f"neighborhood_emergency_frequency={mins}min")
+            else:
+                print(f"⚠️ IP downlink: flood_code_freq index {idx} out of range")
+
+        else:
+            print(f"⚠️ IP downlink: unrecognised command code '{code}' — ignoring")
+
+    if applied:
+        print(f"✅ IP downlink: applied {len(applied)} parameter(s): {', '.join(applied)}")
+    else:
+        print(f"⚠️ IP downlink: no recognised parameters in command "
+              f"(hex={cmd.get('hex_payload', '')})")
+
+    return {
+        "status": "applied",
+        "queue_id": cmd.get("queue_id"),
+        "applied_params": applied,
+        "hex_payload": cmd.get("hex_payload"),
+    }
+
+
 @GRAPHify
 def ttmain(trigger):
     # Import TTClock for the main workflow
@@ -1499,7 +1765,12 @@ def ttmain(trigger):
         
         # Initialize LoRa integration first
         lora_init = initialize_lora_integration(trigger)
-        
+
+        # Poll for queued server commands over IP and apply them before the
+        # capture cycle begins, so any threshold/frequency changes take effect
+        # this iteration.  No-ops silently when ip_upload.enabled=false.
+        ip_downlink = ip_downlink_poll_and_apply(lora_init)
+
         # Validate configuration
         config_validation = validate_configuration(trigger)
         
@@ -1536,7 +1807,13 @@ def ttmain(trigger):
         
         # Use sensor tracker for intelligent LoRa transmission
         lora_return = lora_token_with_tracker(bitmap, sensor_tracker)
-        
+
+        # Parallel IP uplink — sends the same sensor data + bitmap to the
+        # FastAPI server over WiFi/cellular.  No-ops silently when disabled.
+        # Runs concurrently with the LoRa path; LoRa failure does not affect
+        # IP and vice versa.
+        ip_return = ip_uplink_transmit(bitmap, sensor_tracker)
+
         # Shutdown check at GRAPH level
         shutdown_result = call_shutdown(lora_return)
         

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1495,15 +1495,16 @@ def log_sensor_tracking_stats(sensor_tracker):
 
 @SQify
 def ip_uplink_transmit(bitmap, sensor_tracker):
-    """Send sensor readings and flood bitmap to the FastAPI server over IP (WiFi/cellular).
+    """Send a subset of sensor readings and the flood bitmap to the FastAPI server over IP.
 
-    Collects the same sensor data as lora_token_with_tracker, encodes it as
-    channel-coded hex blocks (same format the API already understands for LoRa
-    uplinks), and POSTs to /ip/uplink.
+    Encodes the following channels as channel-coded hex blocks and POSTs to
+    /ip/uplink: device_ts, battery_pct (from WittyPi), GPS lat/lon, temperature,
+    humidity, flood_detect (inferred from bitmap), flood_bitmap, and the five
+    status-report parameters.  IMU data is not included.
 
     Disabled by default — set ip_upload.enabled=true in runtime_config.json to
-    activate.  When fallback_to_lora=true and IP fails, the data has already been
-    sent via LoRa so nothing is lost.
+    activate.  Runs in parallel with the LoRa path; neither path depends on the
+    other completing first.
 
     Returns a status dict (never raises) so a failure here never stops the main
     workflow.
@@ -1635,7 +1636,7 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
         print(f"⚠️ IP uplink failed after {result.get('attempts', '?')} attempt(s): "
               f"{result.get('error', 'unknown error')}")
         if tx.fallback_to_lora:
-            print("📡 LoRa fallback is enabled — data already sent via LoRa path")
+            print("📡 LoRa fallback is enabled — data may also be sent via the LoRa path")
 
     return {
         "status": "ok" if result["success"] else "failed",

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1520,7 +1520,10 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
         print("📡 IP uplink disabled (ip_upload.enabled=false) — skipping")
         return {"status": "disabled", "success": False}
 
-    if not tx.is_reachable():
+    # Use a short timeout for the reachability probe — this runs on every wake
+    # cycle and a full timeout_s (default 15 s) would add significant dead time
+    # when the server is down.
+    if not tx.is_reachable(timeout_s=5):
         print(f"⚠️ IP uplink: server unreachable at {tx.server_url}")
         return {"status": "unreachable", "success": False}
 

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1529,122 +1529,128 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
         tx.close()
         return {"status": "unreachable", "success": False}
 
-    # ── Collect sensor data ────────────────────────────────────────────────────
-    # IMU orientation is not transmitted (no 03 01 channel encoded below);
-    # do not read it here to avoid unnecessary hardware I/O and failure points.
-    data = {}
-
     try:
-        from tools.aht20_temperature import get_aht20
-        data.update(get_aht20())
-    except Exception as e:
-        print(f"⚠️ IP uplink: AHT20 unavailable: {e}")
+        # ── Collect sensor data ────────────────────────────────────────────────
+        # IMU orientation is not transmitted (no 03 01 channel encoded below);
+        # do not read it here to avoid unnecessary hardware I/O and failure points.
+        data = {}
 
-    try:
-        from tools.get_gps import get_location_with_retry
-        gps, _ = get_location_with_retry()
-        if gps:
-            data.update(gps)
-    except Exception as e:
-        print(f"⚠️ IP uplink: GPS unavailable: {e}")
-
-    try:
-        from tools.wittypi_control import get_wittypi_status
-        wittypi_data = get_wittypi_status()
-        if wittypi_data.get('status') == 'wittypi_data_retrieved':
-            data['wittypi_battery_voltage'] = wittypi_data.get('battery_voltage', 0.0)
-    except Exception as e:
-        print(f"⚠️ IP uplink: WittyPi unavailable: {e}")
-
-    data['area_threshold']                    = get_parameter('area_threshold', 10)
-    data['stage_threshold']                   = get_parameter('stage_threshold', 50)
-    data['monitoring_frequency']              = get_parameter('monitoring_frequency', 60)
-    data['emergency_frequency']               = get_parameter('emergency_frequency', 5)
-    data['neighborhood_emergency_frequency']  = get_parameter('neighborhood_emergency_frequency', 30)
-
-    # ── Build channel list ─────────────────────────────────────────────────────
-    channels = []
-    ts_now = int(_time.time())
-
-    # 00 01 — device timestamp (8-byte uint64)
-    channels.append({"code": "00 01", "payload_hex": struct.pack(">Q", ts_now).hex()})
-
-    # 02 01 — battery percent derived from WittyPi voltage (LiPo: 3.0V=0%, 4.2V=100%)
-    batt_v = data.get('wittypi_battery_voltage', 0.0)
-    if batt_v and batt_v > 0:
-        batt_pct = max(0, min(100, int((batt_v - 3.0) / 1.2 * 100)))
-        channels.append({"code": "02 01", "payload_hex": struct.pack(">I", batt_pct).hex()})
-
-    # 04 01 — GPS block (lat int32 microdeg, lon int32 microdeg)
-    lat = data.get('gps_lat')
-    lon = data.get('gps_lon')
-    if lat is not None and lon is not None:
         try:
-            channels.append({
-                "code": "04 01",
-                "payload_hex": struct.pack(">ii",
-                    int(round(lat * 1_000_000)),
-                    int(round(lon * 1_000_000)),
-                ).hex(),
-            })
-        except struct.error as e:
-            print(f"⚠️ IP uplink: GPS encoding error (lat={lat}, lon={lon}): {e}")
+            from tools.aht20_temperature import get_aht20
+            data.update(get_aht20())
+        except Exception as e:
+            print(f"⚠️ IP uplink: AHT20 unavailable: {e}")
 
-    # 05 01 — temperature (int16, value × 100)
-    temp = data.get('temperature_celsius')
-    if temp is not None:
         try:
-            channels.append({"code": "05 01",
-                              "payload_hex": struct.pack(">h", int(round(temp * 100))).hex()})
-        except struct.error as e:
-            print(f"⚠️ IP uplink: temperature encoding error (temp={temp}): {e}")
+            from tools.get_gps import get_location_with_retry
+            gps, _ = get_location_with_retry()
+            if gps:
+                data.update(gps)
+        except Exception as e:
+            print(f"⚠️ IP uplink: GPS unavailable: {e}")
 
-    # 06 01 — humidity (uint8)
-    hum = data.get('relative_humidity')
-    if hum is not None:
-        channels.append({"code": "06 01",
-                         "payload_hex": struct.pack(">B", max(0, min(255, int(hum)))).hex()})
+        try:
+            from tools.wittypi_control import get_wittypi_status
+            wittypi_data = get_wittypi_status()
+            if wittypi_data.get('status') == 'wittypi_data_retrieved':
+                data['wittypi_battery_voltage'] = wittypi_data.get('battery_voltage', 0.0)
+        except Exception as e:
+            print(f"⚠️ IP uplink: WittyPi unavailable: {e}")
 
-    # 07 17 — flood detect (inferred from bitmap content)
-    flood_detected = bool(bitmap and any(b != 0 for b in bitmap))
-    channels.append({"code": "07 17",
-                     "payload_hex": struct.pack(">I", int(flood_detected)).hex()})
+        data['area_threshold']                    = get_parameter('area_threshold', 10)
+        data['stage_threshold']                   = get_parameter('stage_threshold', 50)
+        data['monitoring_frequency']              = get_parameter('monitoring_frequency', 60)
+        data['emergency_frequency']               = get_parameter('emergency_frequency', 5)
+        data['neighborhood_emergency_frequency']  = get_parameter('neighborhood_emergency_frequency', 30)
 
-    # 08 18 — flood bitmap (variable length, only if non-empty)
-    if bitmap:
-        channels.append({"code": "08 18", "payload_hex": bytes(bitmap).hex()})
+        # ── Build channel list ─────────────────────────────────────────────────
+        channels = []
+        ts_now = int(_time.time())
 
-    # 09 xx — status reports
-    channels.append({"code": "09 19",
-                     "payload_hex": struct.pack(">I", int(data['area_threshold'])).hex()})
-    channels.append({"code": "09 29",
-                     "payload_hex": struct.pack(">I", int(data['stage_threshold'])).hex()})
-    channels.append({"code": "09 39",
-                     "payload_hex": struct.pack(">I", int(data['monitoring_frequency'])).hex()})
-    channels.append({"code": "09 49",
-                     "payload_hex": struct.pack(">I", int(data['emergency_frequency'])).hex()})
-    channels.append({"code": "09 59",
-                     "payload_hex": struct.pack(">I",
-                         int(data['neighborhood_emergency_frequency'])).hex()})
+        # 00 01 — device timestamp (8-byte uint64)
+        channels.append({"code": "00 01", "payload_hex": struct.pack(">Q", ts_now).hex()})
 
-    # ── Transmit ───────────────────────────────────────────────────────────────
-    result = tx.send_uplink(channels, device_ts=ts_now)
-    tx.close()
+        # 02 01 — battery percent derived from WittyPi voltage (LiPo: 3.0V=0%, 4.2V=100%)
+        batt_v = data.get('wittypi_battery_voltage', 0.0)
+        if batt_v and batt_v > 0:
+            batt_pct = max(0, min(100, int((batt_v - 3.0) / 1.2 * 100)))
+            channels.append({"code": "02 01", "payload_hex": struct.pack(">I", batt_pct).hex()})
 
-    if result["success"]:
-        print(f"✅ IP uplink OK: {len(channels)} channels sent "
-              f"(attempt {result.get('attempts', '?')})")
-    else:
-        print(f"⚠️ IP uplink failed after {result.get('attempts', '?')} attempt(s): "
-              f"{result.get('error', 'unknown error')}")
-        if tx.fallback_to_lora:
-            print("📡 LoRa fallback is enabled — data may also be sent via the LoRa path")
+        # 04 01 — GPS block (lat int32 microdeg, lon int32 microdeg)
+        lat = data.get('gps_lat')
+        lon = data.get('gps_lon')
+        if lat is not None and lon is not None:
+            try:
+                channels.append({
+                    "code": "04 01",
+                    "payload_hex": struct.pack(">ii",
+                        int(round(lat * 1_000_000)),
+                        int(round(lon * 1_000_000)),
+                    ).hex(),
+                })
+            except struct.error as e:
+                print(f"⚠️ IP uplink: GPS encoding error (lat={lat}, lon={lon}): {e}")
 
-    return {
-        "status": "ok" if result["success"] else "failed",
-        "channels_sent": len(channels),
-        "result": result,
-    }
+        # 05 01 — temperature (int16, value × 100)
+        temp = data.get('temperature_celsius')
+        if temp is not None:
+            try:
+                channels.append({"code": "05 01",
+                                  "payload_hex": struct.pack(">h", int(round(temp * 100))).hex()})
+            except struct.error as e:
+                print(f"⚠️ IP uplink: temperature encoding error (temp={temp}): {e}")
+
+        # 06 01 — humidity (uint8)
+        hum = data.get('relative_humidity')
+        if hum is not None:
+            channels.append({"code": "06 01",
+                             "payload_hex": struct.pack(">B", max(0, min(255, int(hum)))).hex()})
+
+        # 07 17 — flood detect (inferred from bitmap content)
+        flood_detected = bool(bitmap and any(b != 0 for b in bitmap))
+        channels.append({"code": "07 17",
+                         "payload_hex": struct.pack(">I", int(flood_detected)).hex()})
+
+        # 08 18 — flood bitmap (variable length, only if non-empty)
+        if bitmap:
+            channels.append({"code": "08 18", "payload_hex": bytes(bitmap).hex()})
+
+        # 09 xx — status reports; clamped to uint32 range so struct.pack never raises
+        _u32 = lambda v: max(0, min(0xFFFFFFFF, int(v)))
+        channels.append({"code": "09 19",
+                         "payload_hex": struct.pack(">I", _u32(data['area_threshold'])).hex()})
+        channels.append({"code": "09 29",
+                         "payload_hex": struct.pack(">I", _u32(data['stage_threshold'])).hex()})
+        channels.append({"code": "09 39",
+                         "payload_hex": struct.pack(">I", _u32(data['monitoring_frequency'])).hex()})
+        channels.append({"code": "09 49",
+                         "payload_hex": struct.pack(">I", _u32(data['emergency_frequency'])).hex()})
+        channels.append({"code": "09 59",
+                         "payload_hex": struct.pack(">I",
+                             _u32(data['neighborhood_emergency_frequency'])).hex()})
+
+        # ── Transmit ──────────────────────────────────────────────────────────
+        result = tx.send_uplink(channels, device_ts=ts_now)
+
+        if result["success"]:
+            print(f"✅ IP uplink OK: {len(channels)} channels sent "
+                  f"(attempt {result.get('attempts', '?')})")
+        else:
+            print(f"⚠️ IP uplink failed after {result.get('attempts', '?')} attempt(s): "
+                  f"{result.get('error', 'unknown error')}")
+            if tx.fallback_to_lora:
+                print("📡 LoRa fallback is enabled — data may also be sent via the LoRa path")
+
+        return {
+            "status": "ok" if result["success"] else "failed",
+            "channels_sent": len(channels),
+            "result": result,
+        }
+    except Exception as exc:
+        print(f"⚠️ IP uplink: unexpected error: {exc}")
+        return {"status": "error", "success": False, "error": str(exc)}
+    finally:
+        tx.close()
 
 
 @SQify

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1670,6 +1670,11 @@ def ip_downlink_poll_and_apply(lora_init):
         tx.close()
         return {"status": "disabled"}
 
+    if not tx.is_reachable(timeout_s=2):
+        tx.close()
+        print("⚠️ IP downlink poll skipped: server unreachable")
+        return {"status": "unreachable"}
+
     poll_result = tx.poll_downlink()
     tx.close()
 

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1503,8 +1503,8 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
     status-report parameters.  IMU data is not included.
 
     Disabled by default — set ip_upload.enabled=true in runtime_config.json to
-    activate.  Runs in parallel with the LoRa path; neither path depends on the
-    other completing first.
+    activate.  Runs after the LoRa path in the wake cycle; both paths share the
+    same sensor snapshot but neither affects the other's outcome.
 
     Returns a status dict (never raises) so a failure here never stops the main
     workflow.
@@ -1704,12 +1704,20 @@ def ip_downlink_poll_and_apply(lora_init):
     _FF_MIN   = [10, 20, 30, 40, 50, 60]  # flood_code_freq_min allowed values
 
     for part in parts:
-        code        = part.get("code", "").strip()
+        if not isinstance(part, dict):
+            print(f"⚠️ IP downlink: malformed part (expected dict, got {type(part).__name__}) — skipping")
+            continue
+
+        code_raw = part.get("code", "")
         payload_hex = part.get("payload_hex", "")
+        if not isinstance(code_raw, str) or not isinstance(payload_hex, str):
+            print(f"⚠️ IP downlink: non-string code or payload_hex in part {part} — skipping")
+            continue
+        code = code_raw.strip()
 
         try:
             payload_bytes = bytes.fromhex(payload_hex)
-        except ValueError:
+        except (TypeError, ValueError):
             print(f"⚠️ IP downlink: bad payload_hex in part {part} — skipping")
             continue
 
@@ -1824,10 +1832,9 @@ def ttmain(trigger):
         # Use sensor tracker for intelligent LoRa transmission
         lora_return = lora_token_with_tracker(bitmap, sensor_tracker)
 
-        # Parallel IP uplink — sends the same sensor data + bitmap to the
-        # FastAPI server over WiFi/cellular.  No-ops silently when disabled.
-        # Runs concurrently with the LoRa path; LoRa failure does not affect
-        # IP and vice versa.
+        # IP uplink — sends the same sensor snapshot + bitmap to the FastAPI
+        # server over WiFi/cellular.  Runs sequentially after lora_return.
+        # No-ops silently when disabled; a failure here does not affect LoRa.
         ip_return = ip_uplink_transmit(bitmap, sensor_tracker)
 
         # Shutdown check at GRAPH level

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1494,7 +1494,7 @@ def log_sensor_tracking_stats(sensor_tracker):
         return {'status': 'error', 'error': str(e)}
 
 @SQify
-def ip_uplink_transmit(bitmap, sensor_tracker):
+def ip_uplink_transmit(bitmap, _sensor_tracker):
     """Send a subset of sensor readings and the flood bitmap to the FastAPI server over IP.
 
     Encodes the following channels as channel-coded hex blocks and POSTs to
@@ -1600,11 +1600,11 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
             except struct.error as e:
                 print(f"⚠️ IP uplink: temperature encoding error (temp={temp}): {e}")
 
-        # 06 01 — humidity (uint8)
+        # 06 01 — humidity (uint8, 0–100 %)
         hum = data.get('relative_humidity')
         if hum is not None:
             channels.append({"code": "06 01",
-                             "payload_hex": struct.pack(">B", max(0, min(255, int(hum)))).hex()})
+                             "payload_hex": struct.pack(">B", max(0, min(100, int(round(hum))))).hex()})
 
         # 07 17 — flood detect (inferred from bitmap content)
         flood_detected = bool(bitmap and any(b != 0 for b in bitmap))
@@ -1654,7 +1654,7 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
 
 
 @SQify
-def ip_downlink_poll_and_apply(lora_init):
+def ip_downlink_poll_and_apply(_lora_init):
     """Poll /ip/downlink/{device_id} for queued server commands and apply them.
 
     The server queues parameter-update commands when a human operator (or weather
@@ -1695,7 +1695,15 @@ def ip_downlink_poll_and_apply(lora_init):
 
     print(f"📬 IP downlink: received command (queue_id={cmd.get('queue_id')})")
 
-    parts = cmd.get("parts") or []
+    parts_raw = cmd.get("parts")
+    if parts_raw is None:
+        parts = []
+    elif isinstance(parts_raw, list):
+        parts = parts_raw
+    else:
+        print(f"⚠️ IP downlink: malformed parts field "
+              f"(expected list, got {type(parts_raw).__name__}) — treating as empty")
+        parts = []
     applied = []
 
     # Index-based lookup tables — must match server app/encoders.py constants
@@ -1719,6 +1727,13 @@ def ip_downlink_poll_and_apply(lora_init):
             payload_bytes = bytes.fromhex(payload_hex)
         except (TypeError, ValueError):
             print(f"⚠️ IP downlink: bad payload_hex in part {part} — skipping")
+            continue
+
+        # Validate payload width before decoding to avoid silent misinterpretation
+        _expected_len = {"10 90": 1, "11 91": 2, "12 92": 1, "13 93": 1, "14 94": 1}
+        if code in _expected_len and len(payload_bytes) != _expected_len[code]:
+            print(f"⚠️ IP downlink: wrong payload length for {code} "
+                  f"(expected {_expected_len[code]}, got {len(payload_bytes)}) — skipping")
             continue
 
         if code == "10 90":  # area_threshold_pct — direct u8 value

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1518,6 +1518,7 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
 
     if not tx.enabled:
         print("📡 IP uplink disabled (ip_upload.enabled=false) — skipping")
+        tx.close()
         return {"status": "disabled", "success": False}
 
     # Use a short timeout for the reachability probe — this runs on every wake
@@ -1525,16 +1526,13 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
     # when the server is down.
     if not tx.is_reachable(timeout_s=5):
         print(f"⚠️ IP uplink: server unreachable at {tx.server_url}")
+        tx.close()
         return {"status": "unreachable", "success": False}
 
     # ── Collect sensor data ────────────────────────────────────────────────────
+    # IMU orientation is not transmitted (no 03 01 channel encoded below);
+    # do not read it here to avoid unnecessary hardware I/O and failure points.
     data = {}
-
-    try:
-        from tools.bno055_imu import get_orientation
-        data.update(get_orientation())
-    except Exception as e:
-        print(f"⚠️ IP uplink: IMU unavailable: {e}")
 
     try:
         from tools.aht20_temperature import get_aht20
@@ -1631,6 +1629,7 @@ def ip_uplink_transmit(bitmap, sensor_tracker):
 
     # ── Transmit ───────────────────────────────────────────────────────────────
     result = tx.send_uplink(channels, device_ts=ts_now)
+    tx.close()
 
     if result["success"]:
         print(f"✅ IP uplink OK: {len(channels)} channels sent "
@@ -1668,9 +1667,11 @@ def ip_downlink_poll_and_apply(lora_init):
     tx = IPTransmitter()
 
     if not tx.enabled:
+        tx.close()
         return {"status": "disabled"}
 
     poll_result = tx.poll_downlink()
+    tx.close()
 
     if not poll_result["success"]:
         print(f"⚠️ IP downlink poll failed: {poll_result.get('error')}")

--- a/tools/get_gps.py
+++ b/tools/get_gps.py
@@ -60,9 +60,17 @@ def _get_lat_lon_alt_with_packet() -> Tuple[dict, Optional[Any]]:
         return ({}, None)
 
 def get_lat_lon_alt() -> dict:
-    """Get GPS latitude, longitude, and altitude as a dictionary."""
+    """Get GPS latitude, longitude, and altitude as a dictionary.
+    Returns only the dict for backward compatibility; use get_location_with_retry() for (dict, packet).
+    """
     gps_data, _ = _get_lat_lon_alt_with_packet()
     return gps_data
+
+
+def get_loc() -> List[str]:
+    """Alias for get_location() for backward compatibility (e.g. add_metadata logging)."""
+    return get_location()
+
 
 def get_location_with_retry(max_retries: int = 3, delay: float = 1.0) -> Tuple[dict, Optional[Any]]:
     """Get location with retry logic for better reliability.

--- a/tools/transmit_ip.py
+++ b/tools/transmit_ip.py
@@ -37,7 +37,7 @@ Codes used by this device (from API CHANNEL_REGISTRY):
     "07 27"  camera_new_local_max (4 bytes, bool as uint32)
     "08 18"  camera_flood_bitmap  (variable length, raw bitmap bytes as hex string)
     "09 19"  sr_area_threshold_pct        (4 bytes)
-    "09 29"  sr_stage_threshold_pct       (4 bytes)
+    "09 29"  sr_stage_threshold_cm        (4 bytes)
     "09 39"  sr_monitoring_frequency      (4 bytes)
     "09 49"  sr_emergency_frequency       (4 bytes)
     "09 59"  sr_neighborhood_emerg_freq   (4 bytes)

--- a/tools/transmit_ip.py
+++ b/tools/transmit_ip.py
@@ -137,8 +137,8 @@ class IPTransmitter:
         self.server_url: str = (override_url or cfg.get("server_url", "http://localhost:8000")).rstrip("/")
         self.api_key: str = cfg.get("api_key", "")
         self.device_id: str = override_device_id or cfg.get("device_id", "watercam-001")
-        self.timeout_s: int = _coerce_int(cfg.get("timeout_s"), 15)
-        self.retry_attempts: int = _coerce_int(cfg.get("retry_attempts"), 3)
+        self.timeout_s: int = max(1, _coerce_int(cfg.get("timeout_s"), 15))
+        self.retry_attempts: int = max(1, _coerce_int(cfg.get("retry_attempts"), 3))
         self.retry_backoff_s: float = _coerce_float(cfg.get("retry_backoff_s"), 2.0)
         self.fallback_to_lora: bool = cfg.get("fallback_to_lora", True)
 
@@ -222,6 +222,16 @@ class IPTransmitter:
         except requests.exceptions.RequestException as exc:
             return {"success": False, "command": None, "status_code": None,
                     "error": str(exc)}
+
+        if resp.status_code == 404:
+            # Device not yet registered on the server — treat as "no pending commands"
+            # rather than a transport error, so callers handle it uniformly.
+            return {
+                "success": True,
+                "command": None,
+                "status_code": resp.status_code,
+                "error": None,
+            }
 
         if resp.status_code != 200:
             return {

--- a/tools/transmit_ip.py
+++ b/tools/transmit_ip.py
@@ -1,0 +1,376 @@
+"""IP uplink/downlink transport for SU-WaterCam.
+
+Sends sensor channel data to the WaterCam FastAPI server over HTTP (WiFi or
+cellular) and polls for queued downlink commands.  Designed to run outside of
+TickTalkPython so the logic can be tested standalone before integration.
+
+Usage (module)
+--------------
+    from tools.transmit_ip import IPTransmitter
+    tx = IPTransmitter()                  # reads runtime_config.json
+    result = tx.send_uplink(channels)     # list of {"code": "...", "payload_hex": "..."}
+    cmd    = tx.poll_downlink()           # returns command dict or None
+
+Usage (CLI smoke-test)
+----------------------
+    python tools/transmit_ip.py
+
+Configuration
+-------------
+All settings live in runtime_config.json under the "ip_upload" key.  See the
+project docs/IP_TRANSMISSION.md for a full field reference.
+
+Channel format
+--------------
+Each element of `channels` must match the ChannelItem schema the server expects:
+    {"code": "02 01", "payload_hex": "00000064"}
+
+Codes used by this device (from API CHANNEL_REGISTRY):
+    "00 01"  device_ts        (8 bytes, UNIX seconds as u64 big-endian)
+    "02 01"  battery_pct      (4 bytes, uint32)
+    "03 01"  imu_block        (12 bytes)
+    "04 01"  gps_block        (8 bytes: lat int32 /1e6, lon int32 /1e6)
+    "05 01"  temperature_c    (2 bytes, int16 /100.0)
+    "06 01"  humidity_pct     (1 byte, uint8)
+    "07 17"  camera_flood_detect  (4 bytes, bool as uint32)
+    "07 27"  camera_new_local_max (4 bytes, bool as uint32)
+    "08 18"  camera_flood_bitmap  (variable length, raw bitmap bytes as hex string)
+    "09 19"  sr_area_threshold_pct        (4 bytes)
+    "09 29"  sr_stage_threshold_pct       (4 bytes)
+    "09 39"  sr_monitoring_frequency      (4 bytes)
+    "09 49"  sr_emergency_frequency       (4 bytes)
+    "09 59"  sr_neighborhood_emerg_freq   (4 bytes)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Default config path — relative to the project root (one level above tools/).
+_DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "runtime_config.json"
+)
+
+
+def _load_ip_config(config_path: str = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    """Load and return the ip_upload section from runtime_config.json."""
+    with open(config_path) as f:
+        cfg = json.load(f)
+    return cfg.get("ip_upload", {})
+
+
+class IPTransmitter:
+    """Handles uplink posting and downlink polling over HTTP.
+
+    Parameters
+    ----------
+    config_path:
+        Path to runtime_config.json.  Defaults to the project-root copy.
+    override_url:
+        If provided, overrides the server_url from config (useful in tests).
+    override_device_id:
+        If provided, overrides the device_id from config.
+    """
+
+    def __init__(
+        self,
+        config_path: str = _DEFAULT_CONFIG_PATH,
+        override_url: Optional[str] = None,
+        override_device_id: Optional[str] = None,
+    ) -> None:
+        cfg = _load_ip_config(config_path)
+
+        self.enabled: bool = cfg.get("enabled", False)
+        self.server_url: str = (override_url or cfg.get("server_url", "http://localhost:8000")).rstrip("/")
+        self.api_key: str = cfg.get("api_key", "")
+        self.device_id: str = override_device_id or cfg.get("device_id", "watercam-001")
+        self.timeout_s: int = int(cfg.get("timeout_s", 15))
+        self.retry_attempts: int = int(cfg.get("retry_attempts", 3))
+        self.retry_backoff_s: float = float(cfg.get("retry_backoff_s", 2))
+        self.fallback_to_lora: bool = cfg.get("fallback_to_lora", True)
+        self.downlink_poll_interval_s: int = int(cfg.get("downlink_poll_interval_s", 60))
+
+        self._session = requests.Session()
+        if self.api_key:
+            self._session.headers.update({"Authorization": f"Bearer {self.api_key}"})
+        self._session.headers.update({"Content-Type": "application/json"})
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                           #
+    # ------------------------------------------------------------------ #
+
+    def send_uplink(
+        self,
+        channels: List[Dict[str, str]],
+        device_ts: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """POST sensor channel data to /ip/uplink.
+
+        Parameters
+        ----------
+        channels:
+            List of channel dicts, each with "code" and "payload_hex".
+            Example:
+                [
+                    {"code": "02 01", "payload_hex": "00000064"},
+                    {"code": "05 01", "payload_hex": "0B80"},
+                ]
+        device_ts:
+            Optional UNIX epoch (seconds) timestamp from the device clock.
+            When provided, the server uses it as the measurement timestamp
+            instead of the server arrival time.
+
+        Returns
+        -------
+        dict with keys:
+            "success"    : bool
+            "status_code": int or None
+            "response"   : decoded JSON body or None
+            "error"      : error message string or None
+            "attempts"   : number of attempts made
+        """
+        if not channels:
+            return _err_result("send_uplink called with empty channels list")
+
+        payload: Dict[str, Any] = {
+            "device_id": self.device_id,
+            "channels": channels,
+        }
+        if device_ts is not None:
+            payload["device_ts"] = device_ts
+
+        url = f"{self.server_url}/ip/uplink"
+        return self._post_with_retry(url, payload)
+
+    def poll_downlink(self) -> Dict[str, Any]:
+        """GET /ip/downlink/{device_id} to retrieve the oldest pending command.
+
+        The server atomically marks the command as delivered on retrieval, so
+        calling this multiple times without handling the first response will
+        consume queued commands.
+
+        Returns
+        -------
+        dict with keys:
+            "success"    : bool
+            "command"    : dict or None  (None means no pending command)
+            "status_code": int or None
+            "error"      : error message string or None
+        """
+        url = f"{self.server_url}/ip/downlink/{self.device_id}"
+
+        try:
+            resp = self._session.get(url, timeout=self.timeout_s)
+        except requests.exceptions.ConnectionError as exc:
+            return {"success": False, "command": None, "status_code": None,
+                    "error": f"Connection error: {exc}"}
+        except requests.exceptions.Timeout:
+            return {"success": False, "command": None, "status_code": None,
+                    "error": f"Request timed out after {self.timeout_s}s"}
+        except requests.exceptions.RequestException as exc:
+            return {"success": False, "command": None, "status_code": None,
+                    "error": str(exc)}
+
+        if resp.status_code != 200:
+            return {
+                "success": False,
+                "command": None,
+                "status_code": resp.status_code,
+                "error": f"HTTP {resp.status_code}: {resp.text[:200]}",
+            }
+
+        try:
+            body = resp.json()
+        except ValueError:
+            return {"success": False, "command": None,
+                    "status_code": resp.status_code,
+                    "error": "Non-JSON response from server"}
+
+        return {
+            "success": True,
+            "command": body.get("command"),   # dict or None
+            "status_code": resp.status_code,
+            "error": None,
+        }
+
+    def is_reachable(self) -> bool:
+        """Quick check — returns True if the server /health endpoint responds."""
+        try:
+            resp = self._session.get(
+                f"{self.server_url}/health", timeout=self.timeout_s
+            )
+            return resp.status_code == 200
+        except requests.exceptions.RequestException:
+            return False
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _post_with_retry(
+        self, url: str, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """POST payload to url with exponential-ish backoff retry."""
+        last_error: str = "unknown error"
+        last_status: Optional[int] = None
+
+        for attempt in range(1, self.retry_attempts + 1):
+            try:
+                resp = self._session.post(
+                    url, json=payload, timeout=self.timeout_s
+                )
+                last_status = resp.status_code
+
+                if resp.status_code in (200, 201):
+                    try:
+                        body = resp.json()
+                    except ValueError:
+                        body = {"raw": resp.text}
+                    logger.info(
+                        "IP uplink OK (attempt %d/%d): %s",
+                        attempt, self.retry_attempts, resp.status_code,
+                    )
+                    return {
+                        "success": True,
+                        "status_code": resp.status_code,
+                        "response": body,
+                        "error": None,
+                        "attempts": attempt,
+                    }
+
+                # Server-side error — don't retry 4xx (client mistake)
+                if 400 <= resp.status_code < 500:
+                    logger.error(
+                        "IP uplink rejected by server (HTTP %d): %s",
+                        resp.status_code, resp.text[:300],
+                    )
+                    return _err_result(
+                        f"HTTP {resp.status_code}: {resp.text[:200]}",
+                        status_code=resp.status_code,
+                        attempts=attempt,
+                    )
+
+                # 5xx — retry
+                last_error = f"HTTP {resp.status_code}: {resp.text[:200]}"
+                logger.warning(
+                    "IP uplink attempt %d/%d failed with %d, retrying...",
+                    attempt, self.retry_attempts, resp.status_code,
+                )
+
+            except requests.exceptions.ConnectionError as exc:
+                last_error = f"Connection error: {exc}"
+                logger.warning(
+                    "IP uplink attempt %d/%d connection error: %s",
+                    attempt, self.retry_attempts, exc,
+                )
+            except requests.exceptions.Timeout:
+                last_error = f"Timeout after {self.timeout_s}s"
+                logger.warning(
+                    "IP uplink attempt %d/%d timed out", attempt, self.retry_attempts
+                )
+            except requests.exceptions.RequestException as exc:
+                last_error = str(exc)
+                logger.warning(
+                    "IP uplink attempt %d/%d request error: %s",
+                    attempt, self.retry_attempts, exc,
+                )
+
+            if attempt < self.retry_attempts:
+                sleep_s = self.retry_backoff_s * attempt
+                logger.debug("Waiting %.1fs before retry %d", sleep_s, attempt + 1)
+                time.sleep(sleep_s)
+
+        logger.error(
+            "IP uplink failed after %d attempts. Last error: %s",
+            self.retry_attempts, last_error,
+        )
+        return _err_result(
+            last_error,
+            status_code=last_status,
+            attempts=self.retry_attempts,
+        )
+
+
+# ------------------------------------------------------------------ #
+# Module-level convenience functions                                   #
+# ------------------------------------------------------------------ #
+
+def send_uplink(
+    channels: List[Dict[str, str]],
+    device_ts: Optional[int] = None,
+    config_path: str = _DEFAULT_CONFIG_PATH,
+) -> Dict[str, Any]:
+    """Module-level wrapper: create a transmitter and send one uplink."""
+    tx = IPTransmitter(config_path=config_path)
+    return tx.send_uplink(channels, device_ts=device_ts)
+
+
+def poll_downlink(config_path: str = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    """Module-level wrapper: create a transmitter and poll for one downlink."""
+    tx = IPTransmitter(config_path=config_path)
+    return tx.poll_downlink()
+
+
+# ------------------------------------------------------------------ #
+# Internal util                                                        #
+# ------------------------------------------------------------------ #
+
+def _err_result(
+    message: str,
+    status_code: Optional[int] = None,
+    attempts: int = 0,
+) -> Dict[str, Any]:
+    return {
+        "success": False,
+        "status_code": status_code,
+        "response": None,
+        "error": message,
+        "attempts": attempts,
+    }
+
+
+# ------------------------------------------------------------------ #
+# CLI smoke-test                                                       #
+# ------------------------------------------------------------------ #
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    import struct
+
+    tx = IPTransmitter()
+    print(f"Server : {tx.server_url}")
+    print(f"Device : {tx.device_id}")
+    print(f"Enabled: {tx.enabled}")
+    print()
+
+    # Encode a minimal uplink: battery 75%, temperature 22.50 °C
+    battery_hex = struct.pack(">I", 75).hex()            # "0000004B"
+    temp_raw = int(22.50 * 100)                          # 2250 → 0x08CA
+    temp_hex = struct.pack(">h", temp_raw).hex()         # signed int16
+    ts_now = int(time.time())
+    ts_hex = struct.pack(">Q", ts_now).hex()             # 8-byte big-endian u64
+
+    channels = [
+        {"code": "00 01", "payload_hex": ts_hex},
+        {"code": "02 01", "payload_hex": battery_hex},
+        {"code": "05 01", "payload_hex": temp_hex},
+    ]
+
+    print("--- Uplink test ---")
+    print(f"Channels: {json.dumps(channels, indent=2)}")
+    result = tx.send_uplink(channels, device_ts=ts_now)
+    print(f"Result  : {json.dumps(result, indent=2)}")
+
+    print()
+    print("--- Downlink poll ---")
+    dl = tx.poll_downlink()
+    print(f"Result  : {json.dumps(dl, indent=2)}")

--- a/tools/transmit_ip.py
+++ b/tools/transmit_ip.py
@@ -61,6 +61,22 @@ _DEFAULT_CONFIG_PATH = os.path.join(
 )
 
 
+def _coerce_int(value: Any, default: int) -> int:
+    """Return ``int(value)`` or ``default`` if value is missing/invalid."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    """Return ``float(value)`` or ``default`` if value is missing/invalid."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _load_ip_config(config_path: str = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
     """Load and return the ip_upload section from runtime_config.json.
 
@@ -71,8 +87,9 @@ def _load_ip_config(config_path: str = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
     try:
         with open(config_path) as f:
             cfg = json.load(f)
-    except FileNotFoundError:
-        logger.debug("runtime_config.json not found at %s; using defaults", config_path)
+    except OSError as exc:
+        # Covers FileNotFoundError, PermissionError, and other I/O failures.
+        logger.debug("Cannot read config at %s (%s); using defaults", config_path, exc)
         return {}
     except json.JSONDecodeError as exc:
         logger.warning("Invalid JSON in %s: %s; using defaults", config_path, exc)
@@ -116,9 +133,9 @@ class IPTransmitter:
         self.server_url: str = (override_url or cfg.get("server_url", "http://localhost:8000")).rstrip("/")
         self.api_key: str = cfg.get("api_key", "")
         self.device_id: str = override_device_id or cfg.get("device_id", "watercam-001")
-        self.timeout_s: int = int(cfg.get("timeout_s", 15))
-        self.retry_attempts: int = int(cfg.get("retry_attempts", 3))
-        self.retry_backoff_s: float = float(cfg.get("retry_backoff_s", 2))
+        self.timeout_s: int = _coerce_int(cfg.get("timeout_s"), 15)
+        self.retry_attempts: int = _coerce_int(cfg.get("retry_attempts"), 3)
+        self.retry_backoff_s: float = _coerce_float(cfg.get("retry_backoff_s"), 2.0)
         self.fallback_to_lora: bool = cfg.get("fallback_to_lora", True)
 
         self._session = requests.Session()
@@ -241,6 +258,10 @@ class IPTransmitter:
         except requests.exceptions.RequestException:
             return False
 
+    def close(self) -> None:
+        """Close the underlying requests.Session and release pooled connections."""
+        self._session.close()
+
     # ------------------------------------------------------------------ #
     # Internal helpers                                                     #
     # ------------------------------------------------------------------ #
@@ -343,15 +364,21 @@ def send_uplink(
     device_ts: Optional[int] = None,
     config_path: str = _DEFAULT_CONFIG_PATH,
 ) -> Dict[str, Any]:
-    """Module-level wrapper: create a transmitter and send one uplink."""
+    """Module-level wrapper: create a transmitter, send one uplink, then close."""
     tx = IPTransmitter(config_path=config_path)
-    return tx.send_uplink(channels, device_ts=device_ts)
+    try:
+        return tx.send_uplink(channels, device_ts=device_ts)
+    finally:
+        tx.close()
 
 
 def poll_downlink(config_path: str = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
-    """Module-level wrapper: create a transmitter and poll for one downlink."""
+    """Module-level wrapper: create a transmitter, poll for one downlink, then close."""
     tx = IPTransmitter(config_path=config_path)
-    return tx.poll_downlink()
+    try:
+        return tx.poll_downlink()
+    finally:
+        tx.close()
 
 
 # ------------------------------------------------------------------ #

--- a/tools/transmit_ip.py
+++ b/tools/transmit_ip.py
@@ -97,7 +97,11 @@ def _load_ip_config(config_path: str = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
     if not isinstance(cfg, dict):
         logger.warning("Unexpected config format in %s; using defaults", config_path)
         return {}
-    return cfg.get("ip_upload", {})
+    ip_cfg = cfg.get("ip_upload", {})
+    if not isinstance(ip_cfg, dict):
+        logger.warning("ip_upload in %s is not an object; using defaults", config_path)
+        return {}
+    return ip_cfg
 
 
 class IPTransmitter:

--- a/tools/transmit_ip.py
+++ b/tools/transmit_ip.py
@@ -8,8 +8,9 @@ Usage (module)
 --------------
     from tools.transmit_ip import IPTransmitter
     tx = IPTransmitter()                  # reads runtime_config.json
-    result = tx.send_uplink(channels)     # list of {"code": "...", "payload_hex": "..."}
-    cmd    = tx.poll_downlink()           # returns command dict or None
+    result = tx.send_uplink(channels)     # {"success": bool, "status_code": int|None, ...}
+    reply  = tx.poll_downlink()           # {"success": bool, "status_code": int|None, "command": dict|None, ...}
+    cmd    = reply["command"]             # dict or None
 
 Usage (CLI smoke-test)
 ----------------------
@@ -61,9 +62,24 @@ _DEFAULT_CONFIG_PATH = os.path.join(
 
 
 def _load_ip_config(config_path: str = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
-    """Load and return the ip_upload section from runtime_config.json."""
-    with open(config_path) as f:
-        cfg = json.load(f)
+    """Load and return the ip_upload section from runtime_config.json.
+
+    Returns an empty dict (all defaults) if the file is missing or contains
+    invalid JSON — runtime_config.json is gitignored and may not exist in fresh
+    dev or CI environments.
+    """
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+    except FileNotFoundError:
+        logger.debug("runtime_config.json not found at %s; using defaults", config_path)
+        return {}
+    except json.JSONDecodeError as exc:
+        logger.warning("Invalid JSON in %s: %s; using defaults", config_path, exc)
+        return {}
+    if not isinstance(cfg, dict):
+        logger.warning("Unexpected config format in %s; using defaults", config_path)
+        return {}
     return cfg.get("ip_upload", {})
 
 
@@ -78,6 +94,14 @@ class IPTransmitter:
         If provided, overrides the server_url from config (useful in tests).
     override_device_id:
         If provided, overrides the device_id from config.
+
+    Notes
+    -----
+    ``self.enabled`` reflects the ``ip_upload.enabled`` config flag, but
+    ``send_uplink()`` and ``poll_downlink()`` do **not** check it internally —
+    the flag is an integration-layer concern enforced by ``ticktalk_main.py``.
+    Direct callers (tests, CLI smoke-test) are responsible for checking
+    ``tx.enabled`` themselves if they want to respect the flag.
     """
 
     def __init__(
@@ -96,7 +120,6 @@ class IPTransmitter:
         self.retry_attempts: int = int(cfg.get("retry_attempts", 3))
         self.retry_backoff_s: float = float(cfg.get("retry_backoff_s", 2))
         self.fallback_to_lora: bool = cfg.get("fallback_to_lora", True)
-        self.downlink_poll_interval_s: int = int(cfg.get("downlink_poll_interval_s", 60))
 
         self._session = requests.Session()
         if self.api_key:
@@ -201,12 +224,19 @@ class IPTransmitter:
             "error": None,
         }
 
-    def is_reachable(self) -> bool:
-        """Quick check — returns True if the server /health endpoint responds."""
+    def is_reachable(self, timeout_s: Optional[float] = None) -> bool:
+        """Quick check — returns True if the server /health endpoint responds.
+
+        Parameters
+        ----------
+        timeout_s:
+            Override the instance timeout for this call only.  Pass a small
+            value (e.g. 3) in CI/test contexts to fail fast when the server
+            is not running.
+        """
+        t = timeout_s if timeout_s is not None else self.timeout_s
         try:
-            resp = self._session.get(
-                f"{self.server_url}/health", timeout=self.timeout_s
-            )
+            resp = self._session.get(f"{self.server_url}/health", timeout=t)
             return resp.status_code == 200
         except requests.exceptions.RequestException:
             return False
@@ -218,7 +248,12 @@ class IPTransmitter:
     def _post_with_retry(
         self, url: str, payload: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """POST payload to url with exponential-ish backoff retry."""
+        """POST payload to url with exponential backoff retry.
+
+        Sleep before retry N is ``retry_backoff_s * 2^(N-1)`` seconds, so for
+        the default ``retry_backoff_s=2`` and ``retry_attempts=3``:
+        attempt 1 → immediate, attempt 2 → 2 s, attempt 3 → 4 s.
+        """
         last_error: str = "unknown error"
         last_status: Optional[int] = None
 
@@ -284,7 +319,7 @@ class IPTransmitter:
                 )
 
             if attempt < self.retry_attempts:
-                sleep_s = self.retry_backoff_s * attempt
+                sleep_s = self.retry_backoff_s * (2 ** (attempt - 1))
                 logger.debug("Waiting %.1fs before retry %d", sleep_s, attempt + 1)
                 time.sleep(sleep_s)
 


### PR DESCRIPTION
## Summary

Adds a parallel data transport path over HTTP (WiFi/cellular) alongside the existing LoRa pathway. Both paths send identically-encoded channel data to the same FastAPI server; neither blocks the other on failure.

- **`tools/transmit_ip.py`** — `IPTransmitter` class with `send_uplink()`, `poll_downlink()`, `is_reachable()`; exponential-backoff retry; no retry on 4xx; plain Python with no TickTalkPython syntax (testable standalone)
- **`tests/test_ip_upload.py`** — 11 integration tests covering uplink variants, downlink polling, and reachability; skip gracefully when the server is unreachable (CI-safe); all 11 pass against the live server
- **`docs/IP_TRANSMISSION.md`** — full developer reference: config fields, channel encoding table with `struct` examples, API endpoint shapes, test instructions, TickTalkPython integration documentation
- **`runtime_config.example.json`** — committed template for the gitignored per-device `runtime_config.json`, including the new `ip_upload` block
- **`ticktalk_main.py`** — two new `@SQify` nodes wired into `ttmain`:
  - `ip_downlink_poll_and_apply(lora_init)` — polls `/ip/downlink/{device_id}` at wake-cycle start; decodes `parts` and applies parameter updates via `set_parameter()`
  - `ip_uplink_transmit(bitmap, sensor_tracker)` — runs in parallel with `lora_token_with_tracker`; encodes AHT20/GPS/WittyPi/runtime-param channels and POSTs to `/ip/uplink`

## Enabling IP transport

Set `"enabled": true` in the `ip_upload` block of `runtime_config.json`. Both new `@SQify` functions return immediately (no network calls) when disabled — zero overhead for LoRa-only deployments.

## Copilot review items to address before merge

- [ ] **`_load_ip_config()` should handle missing/corrupt config gracefully** — currently raises `FileNotFoundError` / `JSONDecodeError`; wrap in try/except and fall back to `{}`
- [ ] **Module docstring `poll_downlink()` example is wrong** — shows it returning a command dict directly; it returns `{"success", "status_code", "error", "command"}`; update the example
- [ ] **`ip_uplink_transmit` docstring overstates payload coverage** — says "same sensor data as lora_token_with_tracker" but omits `emergency_status` etc.; adjust to describe actual subset
- [ ] **"data already sent via LoRa" log may be incorrect** — both paths can be concurrent; soften to "may be handled via the LoRa path"
- [ ] **`always_transmit_sensors` missing from `runtime_config.example.json`**

## Test plan

- [ ] `python tools/transmit_ip.py` — CLI smoke-test against live server
- [ ] `python tests/test_ip_upload.py` — all 11 integration tests pass
- [ ] Set `ip_upload.enabled=true`, run `ticktalk_main.py`, confirm `✅ IP uplink OK` in logs
- [ ] Queue a downlink via the server dashboard; confirm it is applied on next device wake

## Related

- GPS decoder bug (`04 01` channel) fixed in API repo commit `0a63091`
- Splits IP transport work out of the combined PR #24 (closed). Camera metadata work is in PR #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)