### PR TITLE
issue #21: embed unit ID in photo EXIF and XMP metadata

### DIFF
--- a/tools/add_metadata.py
+++ b/tools/add_metadata.py
@@ -2,7 +2,6 @@
 # embed GPS/IMU data into image EXIF
 # Takes image path as parameter
 
-import json
 import logging
 import os
 import time
@@ -13,28 +12,19 @@ from libxmp import XMPFiles, XMPMeta, consts
 
 logger = logging.getLogger(__name__)
 
-_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "runtime_config.json")
 
-
-def _read_device_id(config_path: str = _CONFIG_PATH) -> str:
-    """Return the device_id from runtime_config.json, or '' if unavailable."""
-    try:
-        with open(config_path) as f:
-            cfg = json.load(f)
-    except OSError as exc:
-        logger.debug("Cannot read config at %s (%s); device_id unavailable", config_path, exc)
-        return ""
-    except json.JSONDecodeError as exc:
-        logger.warning("Invalid JSON in %s: %s; device_id unavailable", config_path, exc)
-        return ""
-    if not isinstance(cfg, dict):
-        logger.warning("Unexpected config format in %s; device_id unavailable", config_path)
-        return ""
-    ip_upload = cfg.get("ip_upload", {})
-    if not isinstance(ip_upload, dict):
-        logger.warning("ip_upload in %s is not an object; device_id unavailable", config_path)
-        return ""
-    return ip_upload.get("device_id", "")
+def _read_device_id() -> str:
+    """Return the device_id from runtime_config.json as an ASCII string, or '' if unavailable."""
+    from tools.transmit_ip import _load_ip_config
+    ip_cfg = _load_ip_config()
+    raw = ip_cfg.get("device_id", "")
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, (int, float, bool)):
+        return str(raw)
+    if raw is not None:
+        logger.warning("device_id in config has unexpected type %s; ignoring", type(raw).__name__)
+    return ""
 
 try:
     from tools import bno055_imu
@@ -114,7 +104,7 @@ def add_metadata(image):
     # Embed unit ID in EXIF BodySerialNumber (tag 0xA431)
     device_id = _read_device_id()
     if device_id:
-        exif_data["Exif"][piexif.ExifIFD.BodySerialNumber] = device_id.encode()
+        exif_data["Exif"][piexif.ExifIFD.BodySerialNumber] = device_id.encode("ascii", errors="replace")
 
     # Add roll/pitch/yaw to UserComment tag if they exist
     if roll is not None:

--- a/tools/add_metadata.py
+++ b/tools/add_metadata.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def _read_device_id() -> str:
-    """Return the device_id from runtime_config.json as an ASCII string, or '' if unavailable."""
+    """Return the device_id from runtime_config.json as a str, or '' if unavailable."""
     from tools.transmit_ip import _load_ip_config
     ip_cfg = _load_ip_config()
     raw = ip_cfg.get("device_id", "")

--- a/tools/add_metadata.py
+++ b/tools/add_metadata.py
@@ -3,12 +3,15 @@
 # Takes image path as parameter
 
 import json
+import logging
 import os
 import time
 from fractions import Fraction
 import piexif
 import piexif.helper
-from libxmp import XMPFiles, consts
+from libxmp import XMPFiles, XMPMeta, consts
+
+logger = logging.getLogger(__name__)
 
 _CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "runtime_config.json")
 
@@ -18,9 +21,20 @@ def _read_device_id(config_path: str = _CONFIG_PATH) -> str:
     try:
         with open(config_path) as f:
             cfg = json.load(f)
-        return cfg.get("ip_upload", {}).get("device_id", "")
-    except Exception:
+    except OSError as exc:
+        logger.debug("Cannot read config at %s (%s); device_id unavailable", config_path, exc)
         return ""
+    except json.JSONDecodeError as exc:
+        logger.warning("Invalid JSON in %s: %s; device_id unavailable", config_path, exc)
+        return ""
+    if not isinstance(cfg, dict):
+        logger.warning("Unexpected config format in %s; device_id unavailable", config_path)
+        return ""
+    ip_upload = cfg.get("ip_upload", {})
+    if not isinstance(ip_upload, dict):
+        logger.warning("ip_upload in %s is not an object; device_id unavailable", config_path)
+        return ""
+    return ip_upload.get("device_id", "")
 
 try:
     from tools import bno055_imu
@@ -118,11 +132,15 @@ def add_metadata(image):
 
     if xmp_props:
         xmpfile = XMPFiles(file_path=image, open_forupdate=True)
-        xmp = xmpfile.get_xmp()
-        for prop, val in xmp_props.items():
-            xmp.set_property(consts.XMP_NS_DC, prop, val)
-        xmpfile.put_xmp(xmp)
-        xmpfile.close_file()
+        try:
+            xmp = xmpfile.get_xmp()
+            if xmp is None:
+                xmp = XMPMeta()
+            for prop, val in xmp_props.items():
+                xmp.set_property(consts.XMP_NS_DC, prop, val)
+            xmpfile.put_xmp(xmp)
+        finally:
+            xmpfile.close_file()
 
     # GPS: get current info from gpsd
     formatted_gps_data = []

--- a/tools/add_metadata.py
+++ b/tools/add_metadata.py
@@ -2,11 +2,25 @@
 # embed GPS/IMU data into image EXIF
 # Takes image path as parameter
 
+import json
+import os
 import time
 from fractions import Fraction
 import piexif
 import piexif.helper
 from libxmp import XMPFiles, consts
+
+_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "runtime_config.json")
+
+
+def _read_device_id(config_path: str = _CONFIG_PATH) -> str:
+    """Return the device_id from runtime_config.json, or '' if unavailable."""
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+        return cfg.get("ip_upload", {}).get("device_id", "")
+    except Exception:
+        return ""
 
 try:
     from tools import bno055_imu
@@ -76,23 +90,37 @@ def add_metadata(image):
         with open(DATA, 'a', encoding="utf8") as data:
             for line in imu:
                 data.writelines(line)
-        
+
         yaw, roll, pitch = imu_values['Euler']
 
     # Start exif handling
     # load original exif data
     exif_data = piexif.load(image)
+
+    # Embed unit ID in EXIF BodySerialNumber (tag 0xA431)
+    device_id = _read_device_id()
+    if device_id:
+        exif_data["Exif"][piexif.ExifIFD.BodySerialNumber] = device_id.encode()
+
     # Add roll/pitch/yaw to UserComment tag if they exist
     if roll is not None:
         user_comment = piexif.helper.UserComment.dump(f"Roll {roll} Pitch {pitch} Yaw {yaw}")
         exif_data["Exif"][piexif.ExifIFD.UserComment] = user_comment
-        
-        # Write roll/pitch/yaw to XMP tags for Pix4D
+
+    # Write XMP tags for Pix4D: unit ID always, orientation when available
+    xmp_props: dict = {}
+    if device_id:
+        xmp_props["DeviceID"] = device_id
+    if roll is not None:
+        xmp_props["Roll"] = str(roll)
+        xmp_props["Pitch"] = str(pitch)
+        xmp_props["Yaw"] = str(yaw)
+
+    if xmp_props:
         xmpfile = XMPFiles(file_path=image, open_forupdate=True)
         xmp = xmpfile.get_xmp()
-        xmp.set_property(consts.XMP_NS_DC, 'Roll', str(roll))
-        xmp.set_property(consts.XMP_NS_DC, 'Pitch', str(pitch))
-        xmp.set_property(consts.XMP_NS_DC, 'Yaw', str(yaw))
+        for prop, val in xmp_props.items():
+            xmp.set_property(consts.XMP_NS_DC, prop, val)
         xmpfile.put_xmp(xmp)
         xmpfile.close_file()
 

--- a/tools/add_metadata.py
+++ b/tools/add_metadata.py
@@ -3,7 +3,6 @@
 # Takes image path as parameter
 
 import logging
-import os
 import time
 from fractions import Fraction
 import piexif


### PR DESCRIPTION
Read device_id from runtime_config.json (ip_upload.device_id) and write it to EXIF BodySerialNumber (tag 0xA431) and XMP dc:DeviceID on every captured image. XMP is now written in a single open/close block covering both the unit ID and orientation tags, rather than only when IMU data is available.