### PR TITLE
fix: graceful degradation for missing/faulty AHT20, BNO055, and Lepto…

### DIFF
--- a/tools/add_metadata.py
+++ b/tools/add_metadata.py
@@ -82,19 +82,23 @@ def add_metadata(image):
         imu_values = bno055_imu.get_values()
     except Exception as error:
         print("IMU Error")
-    else:
+        imu_values = {}
+
+    if imu_values:
         # log IMU data to text file
         imu = [f"\nFile: {image}\n",
             f"Time: {time.asctime(time.localtime(time.time()))}\n",
-            f"Accelerometer: {imu_values['Accelerometer']}\n",
-            f"Gyro: {imu_values['Gyro']}\n",
-            f"Temperature: {imu_values['Temperature']}\n"]
+            f"Accelerometer: {imu_values.get('Accelerometer')}\n",
+            f"Gyro: {imu_values.get('Gyro')}\n",
+            f"Temperature: {imu_values.get('Temperature')}\n"]
 
         with open(DATA, 'a', encoding="utf8") as data:
             for line in imu:
                 data.writelines(line)
 
-        yaw, roll, pitch = imu_values['Euler']
+        euler = imu_values.get('Euler')
+        if isinstance(euler, tuple) and len(euler) == 3:
+            yaw, roll, pitch = euler
 
     # Start exif handling
     # load original exif data

--- a/tools/aht20_temperature.py
+++ b/tools/aht20_temperature.py
@@ -1,38 +1,62 @@
 #!/usr/bin/env python3
 # get temp & humidity reading from Adafruit AHT20
-import board
+try:
+    import board
+except Exception:
+    board = None
 
 try:
     import adafruit_ahtx0
 except ImportError:
-    print("Error: AHT20 import")
-except:
-    print("Error: AHT20 hardware")
+    adafruit_ahtx0 = None
 
-SENSOR = adafruit_ahtx0.AHTx0(board.I2C())
+_sensor = None
+
+
+def _get_sensor():
+    global _sensor
+    if _sensor is not None:
+        return _sensor
+    if board is None or adafruit_ahtx0 is None:
+        return None
+    try:
+        _sensor = adafruit_ahtx0.AHTx0(board.I2C())
+        return _sensor
+    except Exception:
+        return None
+
 
 def record_csv():
     from time import sleep
     from datetime import datetime
     from csv import DictWriter
     FILE = '/home/pi/SU-WaterCam/data/temp_humidity.csv'
-    
+
     while True:
+        sensor = _get_sensor()
+        if sensor is None:
+            print("AHT20 unavailable")
+            sleep(60)
+            continue
         row = {'Time':datetime.now().strftime('%Y%m%d-%H%M%S'),
-               'Temp': '%0.1f C' % SENSOR.temperature, 'Humidity': '%0.1f %%' %
-               SENSOR.relative_humidity}
+               'Temp': '%0.1f C' % sensor.temperature, 'Humidity': '%0.1f %%' %
+               sensor.relative_humidity}
         print(row)
 
         with open(FILE, 'a+', newline='') as out:
-            #DictWriter(out, row.keys()).writeheader()
             DictWriter(out, row.keys()).writerow(row)
 
         sleep(60)
 
 def get_aht20():
-    data = {"temperature_celsius": float("%0.1f" % SENSOR.temperature),
-            "relative_humidity": int(float("%0.1f" % SENSOR.relative_humidity))}
-    return data
+    sensor = _get_sensor()
+    if sensor is None:
+        return {}
+    try:
+        return {"temperature_celsius": float("%0.1f" % sensor.temperature),
+                "relative_humidity": int(float("%0.1f" % sensor.relative_humidity))}
+    except Exception:
+        return {}
 
 if __name__ == '__main__':
     import sys

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -27,31 +27,23 @@ def take_photo(directory: str, nir: str, picam2) -> str:
 @SQify
 def flir(directory):
     from os import chdir, rename, makedirs, path
-    from time import sleep
     import subprocess
     from datetime import datetime
-    import inspect
-    import sys
-    from pathlib import Path
     date = datetime.now().strftime('%Y%m%d-%H%M%S')
 
     # Flir Lepton 3.5 capture and lepton binaries for image and radiometery
-    # Resolve project root NOW (before any chdir) so Path.cwd() is still valid.
-    def _safe_project_root():
-        try:
-            fpath = inspect.getfile(flir)
-            return path.dirname(path.abspath(fpath))
-        except Exception:
-            try:
-                mod_file = sys.modules.get(__name__).__dict__.get('__file__')
-                if mod_file:
-                    return path.dirname(path.abspath(mod_file))
-            except Exception:
-                pass
-            return str(Path.cwd())
+    # Derive project root from directory (always <root>/images/<date>), then
+    # scan upward for the capture binary as a cross-check.  Must be computed
+    # before any chdir so we are not misled by a changed working directory.
+    def _find_project_root(start):
+        candidate = path.abspath(start)
+        for _ in range(6):
+            candidate = path.dirname(candidate)
+            if path.exists(path.join(candidate, "capture")):
+                return candidate
+        return None
 
-    # Resolve project root and binary paths before any chdir.
-    project_root = _safe_project_root()
+    project_root = _find_project_root(directory) or path.dirname(path.dirname(path.abspath(directory)))
     capture_bin = path.join(project_root, "capture") if path.exists(path.join(project_root, "capture")) else None
     lepton_bin = path.join(project_root, "lepton") if path.exists(path.join(project_root, "lepton")) else None
 

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -36,7 +36,7 @@ def flir(directory):
     date = datetime.now().strftime('%Y%m%d-%H%M%S')
 
     # Flir Lepton 3.5 capture and lepton binaries for image and radiometery
-    # Ensure target directory exists (create fallback if needed)
+    # Resolve project root NOW (before any chdir) so Path.cwd() is still valid.
     def _safe_project_root():
         try:
             fpath = inspect.getfile(flir)
@@ -50,6 +50,12 @@ def flir(directory):
                 pass
             return str(Path.cwd())
 
+    # Resolve project root and binary paths before any chdir.
+    project_root = _safe_project_root()
+    capture_bin = path.join(project_root, "capture") if path.exists(path.join(project_root, "capture")) else None
+    lepton_bin = path.join(project_root, "lepton") if path.exists(path.join(project_root, "lepton")) else None
+
+    # Ensure target directory exists (create fallback if needed)
     need_fallback = False
     try:
         if not path.isdir(directory):
@@ -63,26 +69,19 @@ def flir(directory):
         need_fallback = True
 
     if need_fallback:
-        project_root = _safe_project_root()
         directory = path.join(project_root, 'images', 'fallback')
         try:
             makedirs(directory, exist_ok=True)
         except Exception:
-            directory = path.join(_safe_project_root(), 'images')
+            directory = path.join(project_root, 'images')
             makedirs(directory, exist_ok=True)
 
     try:
         chdir(directory)
     except Exception:
-        project_root = _safe_project_root()
         directory = path.join(project_root, 'images', 'fallback')
         makedirs(directory, exist_ok=True)
         chdir(directory)
-
-    # Resolve binary paths using project root
-    project_root = _safe_project_root()
-    capture_bin = next((p for p in [path.join(project_root, "capture")] if path.exists(p)), None)
-    lepton_bin = next((p for p in [path.join(project_root, "lepton")] if path.exists(p)), None)
 
     try:
         if not capture_bin:


### PR DESCRIPTION
…n hardware

- aht20_temperature.py: replace module-level SENSOR init with lazy _get_sensor() so a missing AHT20 (I2C addr 0x38) no longer raises ValueError on import and crashes the TTPython process; get_aht20() returns {} when unavailable
- add_metadata.py: guard BNO055 imu_values dict access with .get() and an emptiness check so a missing BNO055 no longer raises KeyError ('Accelerometer') and propagates as "Metadata write failed"
- tt_take_photos.py: resolve project root and binary paths before chdir() so the Path.cwd() fallback in _safe_project_root() still points to the project root; previously the Lepton capture/lepton binaries resolved to None after chdir into the images subdirectory, silently failing every capture