### PR TITLE
fix: port robust flir() implementation from button_hold_camera.py

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,94 @@
+# Known Issues & Improvement Backlog
+
+Findings from a codebase audit conducted 2026-04-19. Issues are grouped by severity.
+
+---
+
+## Critical — System Failure
+
+### Serial port opened at import, never closed
+**File:** `tools/lora_handler.py:34`
+Global `ser` is created at module load time and never closed. Blocks other processes from accessing the port; causes resource exhaustion on repeated imports.
+**Fix:** Use a context manager or close in a shutdown handler.
+
+### Serial port open failure is non-fatal
+**File:** `tools/lora_handler.py:44`
+If `ser.is_open` is false after init, code prints a warning and continues. Downstream `transmit()` calls then fail with confusing errors.
+**Fix:** Raise an exception or return an error status instead of continuing.
+
+### Listen loop reads serial without transmit lock
+**File:** `tools/lora_handler_concurrent.py:168`
+`_listen_loop()` reads from the serial port without acquiring `transmit_lock`. Concurrent read and write operations corrupt messages.
+**Fix:** Acquire the same lock in `_listen_loop()` during serial reads.
+
+### `gpsd.connect()` called at module import with no error handling
+**File:** `tools/get_gps.py:8`
+If the gpsd daemon is not running, importing this module raises an uncaught exception and crashes the caller.
+**Fix:** Wrap in `try/except`, set an `_gps_available` flag, return empty data gracefully.
+
+### Bare `except:` and call to undefined `killScript()`
+**File:** `tools/lora_functions.py:93`
+A bare `except:` swallows `SystemExit` and `KeyboardInterrupt`. The handler then calls `killScript()`, which is not defined, raising `NameError`.
+**Fix:** Catch specific exceptions (e.g., `serial.SerialException`, `IndexError`). Define or import `killScript()`.
+
+---
+
+## High — Data Loss or Corruption
+
+### No file lock on LoRa config read/write
+**File:** `tools/lora_handler_concurrent.py:142–154`
+`load_config()` and `save_config()` have no file-level lock. Two processes writing `lora_config.json` simultaneously will corrupt it.
+**Fix:** Use `fcntl.flock()` around file open/write.
+
+### Received LoRa payload parsed without bounds checking
+**File:** `tools/lora_runtime_integration.py:545`
+Channel, command, and value fields are extracted from the payload without range validation. A malformed packet can set out-of-range thresholds or frequencies.
+**Fix:** Validate parsed integers against expected ranges before applying them.
+
+### `pickle.load()` on graph file without source validation
+**Files:** `ticktalk_main.py`, `runrtm.py`
+The TickTalkPython graph is loaded with `pickle.load()` from a file path. If that file is replaced by an attacker, it executes arbitrary code.
+**Fix:** Validate the file's integrity (checksum or signature) before loading, or migrate to a safe serialization format.
+
+---
+
+## Medium — Incorrect Behavior
+
+### GPS packet attributes accessed without mode check
+**File:** `tools/add_metadata.py:152`
+`packet.lat`, `packet.lon`, and `packet.alt` are accessed without checking `packet.mode`. A 2D fix (mode 2) has no altitude; mode < 2 has no position at all. Results in `AttributeError` or stale/zero coordinates written into image metadata.
+**Fix:** Check `packet.mode >= 3` before accessing altitude; `>= 2` for lat/lon.
+
+### `sq_state` dict access is not thread-safe
+**File:** `tt_take_photos.py:141`
+The `Picamera2()` instance is stored in a global `sq_state` dict without a lock. Two concurrent SQ nodes can both read `None` and both create camera instances simultaneously.
+**Fix:** Guard the check-and-set with a `threading.Lock()`.
+
+### IMU warmup timeout is silent
+**File:** `tools/bno055_imu.py:33`
+The warmup loop exits after 2 s even if Euler data never becomes valid. The caller cannot distinguish real zero-rotation from a timeout, and no warning is logged.
+**Fix:** Log a warning on timeout; return a status flag or raise an exception.
+
+### Parameter update callbacks can recurse infinitely
+**File:** `tools/lora_runtime_integration.py:210`
+`set_parameter()` invokes registered callbacks synchronously. A callback that calls `set_parameter()` again will recurse until the stack overflows.
+**Fix:** Document that callbacks must not call `set_parameter()`; or dispatch callbacks via a queue/thread pool.
+
+---
+
+## Inconsistencies
+
+### Temperature sensor returns formatted string; IMU returns raw float
+**Files:** `tools/aht20_temperature.py:40`, `tools/bno055_imu.py:65`
+`aht20_temperature.py` returns `'23.5 C'` (string); `bno055_imu.py` returns `23.5` (float). Callers must handle both formats.
+**Fix:** Standardize all sensor functions to return raw numeric types; format at the display/log layer.
+
+### `get_gps.py` returns `{}` in some paths and `None` in others
+**File:** `tools/get_gps.py`
+Different functions return inconsistent sentinel values for "no data available". Callers must check for both.
+**Fix:** Standardize to always return an empty dict `{}` when data is unavailable.
+
+### Hardcoded `/home/pi/SU-WaterCam/` paths in ~9 files
+**Files:** Multiple (button service scripts, ticktalk_main.py, others)
+Deployment to any user other than `pi`, or to a different path, silently breaks these files.
+**Fix:** Use an environment variable (e.g., `WATERCAM_ROOT`) or derive the root from `__file__` at runtime.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -41,7 +41,7 @@ A bare `except:` swallows `SystemExit` and `KeyboardInterrupt`. The handler then
 **Fix:** Use `fcntl.flock()` around file open/write.
 
 ### Received LoRa payload parsed without bounds checking
-**File:** `tools/lora_runtime_integration.py:545`
+**File:** `tools/lora_runtime_integration.py` (~line 350, `process_lora_command`)
 Channel, command, and value fields are extracted from the payload without range validation. A malformed packet can set out-of-range thresholds or frequencies.
 **Fix:** Validate parsed integers against expected ranges before applying them.
 

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -77,7 +77,7 @@ def flir(directory):
 
         if not path.isfile(command[0]):
             print(f"Check Lepton state - {label} binary not found: {command[0]}")
-            return False
+            return []
 
         if label == "capture":
             out_glob = path.join(directory, "IMG_*.pgm")
@@ -99,16 +99,16 @@ def flir(directory):
         except subprocess.TimeoutExpired:
             print(f"Check Lepton state - {label} timed out")
             _reset_lepton()
-            return False
+            return []
         except Exception as exc:
             print(f"Check Lepton state - {label} failed: {exc}")
             _reset_lepton()
-            return False
+            return []
 
         if proc.returncode != 0:
             print(f"Check Lepton state - {label} failed (rc={proc.returncode})")
             _reset_lepton()
-            return False
+            return []
 
         MTIME_SLOP_SEC = 1
         # Verify output was written during this run. Allow a small mtime slop

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -46,7 +46,18 @@ def flir(directory):
     lepton_bin  = path.join(project_root, "lepton")
     lepton_reset = path.join(project_root, "tools", "lepton_reset.py")
 
-    makedirs(directory, exist_ok=True)
+    try:
+        makedirs(directory, exist_ok=True)
+    except Exception as exc:
+        fallback_directory = path.join(project_root, "images", "fallback")
+        print(f"Unable to create FLIR output directory '{directory}': {exc}")
+        try:
+            makedirs(fallback_directory, exist_ok=True)
+            print(f"Falling back to FLIR output directory '{fallback_directory}'")
+            directory = fallback_directory
+        except Exception as fallback_exc:
+            print(f"Unable to create fallback FLIR output directory '{fallback_directory}': {fallback_exc}")
+            return False
 
     def _reset_lepton():
         import sys
@@ -118,16 +129,18 @@ def flir(directory):
         return True
 
     # Rename outputs to timestamped names matching the coregistration pipeline's expectations.
+    # Select by mtime so we rename the file just produced, not a stale older match.
     for src_glob, dst_name in [
         (path.join(directory, "IMG_*.pgm"),          f"lepton_{date}.pgm"),
         (path.join(directory, "lepton_temp_*.csv"),  f"temperatures_{date}.csv"),
     ]:
-        matches = sorted(glob(src_glob))
+        matches = glob(src_glob)
         if matches:
+            src_path = max(matches, key=path.getmtime)
             try:
-                rename(matches[0], path.join(directory, dst_name))
+                rename(src_path, path.join(directory, dst_name))
             except Exception as exc:
-                print(f"Could not rename {matches[0]}: {exc}")
+                print(f"Could not rename {src_path}: {exc}")
 
     return True
 

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -121,28 +121,31 @@ def flir(directory):
             if not fresh:
                 print(f"Check Lepton state - {label} completed but no fresh output found")
                 _reset_lepton()
-                return False
+                return []
+            return fresh
 
-        return True
+        return []
 
-    if not _run_flir_cmd("capture", [capture_bin]):
+    # Return fresh paths from each command so the rename step uses exactly
+    # the files produced by this run — no re-glob that could match a file
+    # from a concurrent run sharing the same (fallback) directory.
+    capture_fresh = _run_flir_cmd("capture", [capture_bin])
+    if not capture_fresh:
         return True
-    if not _run_flir_cmd("lepton", [lepton_bin]):
+    lepton_fresh = _run_flir_cmd("lepton", [lepton_bin])
+    if not lepton_fresh:
         return True
 
     # Rename outputs to timestamped names matching the coregistration pipeline's expectations.
-    # Select by mtime so we rename the file just produced, not a stale older match.
-    for src_glob, dst_name in [
-        (path.join(directory, "IMG_*.pgm"),          f"lepton_{date}.pgm"),
-        (path.join(directory, "lepton_temp_*.csv"),  f"temperatures_{date}.csv"),
+    for fresh_files, dst_name in [
+        (capture_fresh, f"lepton_{date}.pgm"),
+        (lepton_fresh,  f"temperatures_{date}.csv"),
     ]:
-        matches = glob(src_glob)
-        if matches:
-            src_path = max(matches, key=path.getmtime)
-            try:
-                rename(src_path, path.join(directory, dst_name))
-            except Exception as exc:
-                print(f"Could not rename {src_path}: {exc}")
+        src_path = max(fresh_files, key=path.getmtime)
+        try:
+            rename(src_path, path.join(directory, dst_name))
+        except Exception as exc:
+            print(f"Could not rename {src_path}: {exc}")
 
     return True
 

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -110,11 +110,14 @@ def flir(directory):
             _reset_lepton()
             return False
 
-        # Verify output was written during this run (mtime >= start_time).
+        MTIME_SLOP_SEC = 1
+        # Verify output was written during this run. Allow a small mtime slop
+        # for filesystems with coarse timestamp granularity and minor clock /
+        # timestamp-recording skew, while still requiring output to be fresh.
         # Using mtime handles both new files and overwrites of existing files,
         # so validation stays correct when the fallback directory is reused.
         if out_glob is not None:
-            fresh = [f for f in glob(out_glob) if path.getmtime(f) >= start_time - 1]
+            fresh = [f for f in glob(out_glob) if path.getmtime(f) >= start_time - MTIME_SLOP_SEC]
             if not fresh:
                 print(f"Check Lepton state - {label} completed but no fresh output found")
                 _reset_lepton()

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -57,7 +57,7 @@ def flir(directory):
             directory = fallback_directory
         except Exception as fallback_exc:
             print(f"Unable to create fallback FLIR output directory '{fallback_directory}': {fallback_exc}")
-            return False
+            return True
 
     def _reset_lepton():
         import sys
@@ -73,17 +73,20 @@ def flir(directory):
             print(f"Lepton reset failed: {exc}")
 
     def _run_flir_cmd(label, command):
+        import time
+
         if not path.isfile(command[0]):
             print(f"Check Lepton state - {label} binary not found: {command[0]}")
             return False
 
         if label == "capture":
-            before = set(glob(path.join(directory, "IMG_*.pgm")))
+            out_glob = path.join(directory, "IMG_*.pgm")
         elif label == "lepton":
-            before = set(glob(path.join(directory, "lepton_temp_*.csv")))
+            out_glob = path.join(directory, "lepton_temp_*.csv")
         else:
-            before = set()
+            out_glob = None
 
+        start_time = time.time()
         try:
             proc = subprocess.run(
                 command,
@@ -107,17 +110,13 @@ def flir(directory):
             _reset_lepton()
             return False
 
-        # Verify a new output file appeared (not satisfied by pre-existing files).
-        if label == "capture":
-            after = set(glob(path.join(directory, "IMG_*.pgm")))
-            if not (after - before):
-                print("Check Lepton state - capture completed but no new IMG_*.pgm found")
-                _reset_lepton()
-                return False
-        elif label == "lepton":
-            after = set(glob(path.join(directory, "lepton_temp_*.csv")))
-            if not (after - before):
-                print("Check Lepton state - radiometry completed but no lepton_temp_*.csv found")
+        # Verify output was written during this run (mtime >= start_time).
+        # Using mtime handles both new files and overwrites of existing files,
+        # so validation stays correct when the fallback directory is reused.
+        if out_glob is not None:
+            fresh = [f for f in glob(out_glob) if path.getmtime(f) >= start_time - 1]
+            if not fresh:
+                print(f"Check Lepton state - {label} completed but no fresh output found")
                 _reset_lepton()
                 return False
 

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -26,7 +26,7 @@ def take_photo(directory: str, nir: str, picam2) -> str:
 
 @SQify
 def flir(directory):
-    from os import makedirs, path, listdir, rename
+    from os import makedirs, path, rename
     from glob import glob
     import subprocess
     from datetime import datetime
@@ -49,9 +49,13 @@ def flir(directory):
     makedirs(directory, exist_ok=True)
 
     def _reset_lepton():
+        import sys
+        if not path.isfile(lepton_reset):
+            print(f"Lepton reset script not found: {lepton_reset}")
+            return
         try:
             subprocess.run(
-                [lepton_reset], check=True, timeout=10,
+                [sys.executable, lepton_reset], check=True, timeout=10,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
         except Exception as exc:
@@ -61,6 +65,14 @@ def flir(directory):
         if not path.isfile(command[0]):
             print(f"Check Lepton state - {label} binary not found: {command[0]}")
             return False
+
+        if label == "capture":
+            before = set(glob(path.join(directory, "IMG_*.pgm")))
+        elif label == "lepton":
+            before = set(glob(path.join(directory, "lepton_temp_*.csv")))
+        else:
+            before = set()
+
         try:
             proc = subprocess.run(
                 command,
@@ -84,22 +96,17 @@ def flir(directory):
             _reset_lepton()
             return False
 
-        # Verify expected output file appeared in the session directory.
-        try:
-            files = listdir(directory)
-        except Exception as exc:
-            print(f"Check Lepton state - {label} could not inspect output dir: {exc}")
-            _reset_lepton()
-            return False
-
+        # Verify a new output file appeared (not satisfied by pre-existing files).
         if label == "capture":
-            if not any(f.lower().endswith(".pgm") for f in files):
-                print("Check Lepton state - capture completed but no .pgm output found")
+            after = set(glob(path.join(directory, "IMG_*.pgm")))
+            if not (after - before):
+                print("Check Lepton state - capture completed but no new IMG_*.pgm found")
                 _reset_lepton()
                 return False
         elif label == "lepton":
-            if not any(f.startswith("lepton_temp_") and f.lower().endswith(".csv") for f in files):
-                print("Check Lepton state - radiometery completed but no lepton_temp_*.csv found")
+            after = set(glob(path.join(directory, "lepton_temp_*.csv")))
+            if not (after - before):
+                print("Check Lepton state - radiometry completed but no lepton_temp_*.csv found")
                 _reset_lepton()
                 return False
 

--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -26,15 +26,13 @@ def take_photo(directory: str, nir: str, picam2) -> str:
 
 @SQify
 def flir(directory):
-    from os import chdir, rename, makedirs, path
+    from os import makedirs, path, listdir, rename
+    from glob import glob
     import subprocess
     from datetime import datetime
+
     date = datetime.now().strftime('%Y%m%d-%H%M%S')
 
-    # Flir Lepton 3.5 capture and lepton binaries for image and radiometery
-    # Derive project root from directory (always <root>/images/<date>), then
-    # scan upward for the capture binary as a cross-check.  Must be computed
-    # before any chdir so we are not misled by a changed working directory.
     def _find_project_root(start):
         candidate = path.abspath(start)
         for _ in range(6):
@@ -44,56 +42,85 @@ def flir(directory):
         return None
 
     project_root = _find_project_root(directory) or path.dirname(path.dirname(path.abspath(directory)))
-    capture_bin = path.join(project_root, "capture") if path.exists(path.join(project_root, "capture")) else None
-    lepton_bin = path.join(project_root, "lepton") if path.exists(path.join(project_root, "lepton")) else None
+    capture_bin = path.join(project_root, "capture")
+    lepton_bin  = path.join(project_root, "lepton")
+    lepton_reset = path.join(project_root, "tools", "lepton_reset.py")
 
-    # Ensure target directory exists (create fallback if needed)
-    need_fallback = False
-    try:
-        if not path.isdir(directory):
-            if directory.startswith('/home/pi/') or directory == '/home/pi':
-                need_fallback = True
-            else:
-                makedirs(directory, exist_ok=True)
-    except PermissionError:
-        need_fallback = True
-    except Exception:
-        need_fallback = True
+    makedirs(directory, exist_ok=True)
 
-    if need_fallback:
-        directory = path.join(project_root, 'images', 'fallback')
+    def _reset_lepton():
         try:
-            makedirs(directory, exist_ok=True)
-        except Exception:
-            directory = path.join(project_root, 'images')
-            makedirs(directory, exist_ok=True)
+            subprocess.run(
+                [lepton_reset], check=True, timeout=10,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        except Exception as exc:
+            print(f"Lepton reset failed: {exc}")
 
-    try:
-        chdir(directory)
-    except Exception:
-        directory = path.join(project_root, 'images', 'fallback')
-        makedirs(directory, exist_ok=True)
-        chdir(directory)
+    def _run_flir_cmd(label, command):
+        if not path.isfile(command[0]):
+            print(f"Check Lepton state - {label} binary not found: {command[0]}")
+            return False
+        try:
+            proc = subprocess.run(
+                command,
+                timeout=20,
+                cwd=directory,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"Check Lepton state - {label} timed out")
+            _reset_lepton()
+            return False
+        except Exception as exc:
+            print(f"Check Lepton state - {label} failed: {exc}")
+            _reset_lepton()
+            return False
 
-    try:
-        if not capture_bin:
-            raise FileNotFoundError("capture binary not found")
-        subprocess.run([capture_bin], check=True, timeout=5)
-    except:
-        print("Check Lepton state - capture failed")
-    else:
-        print(f"change name to include {date}")
-        rename("IMG_0000.pgm", f"lepton_{date}.pgm")
+        if proc.returncode != 0:
+            print(f"Check Lepton state - {label} failed (rc={proc.returncode})")
+            _reset_lepton()
+            return False
 
-    try:
-        if not lepton_bin:
-            raise FileNotFoundError("lepton binary not found")
-        subprocess.run([lepton_bin], check=True, timeout=5)
-    except:
-        print("Check Lepton state - radiometery failed")
-    else:
-        print(f"change name to include {date}")
-        rename("lepton_temp_0000.csv", f"temperatures_{date}.csv")
+        # Verify expected output file appeared in the session directory.
+        try:
+            files = listdir(directory)
+        except Exception as exc:
+            print(f"Check Lepton state - {label} could not inspect output dir: {exc}")
+            _reset_lepton()
+            return False
+
+        if label == "capture":
+            if not any(f.lower().endswith(".pgm") for f in files):
+                print("Check Lepton state - capture completed but no .pgm output found")
+                _reset_lepton()
+                return False
+        elif label == "lepton":
+            if not any(f.startswith("lepton_temp_") and f.lower().endswith(".csv") for f in files):
+                print("Check Lepton state - radiometery completed but no lepton_temp_*.csv found")
+                _reset_lepton()
+                return False
+
+        return True
+
+    if not _run_flir_cmd("capture", [capture_bin]):
+        return True
+    if not _run_flir_cmd("lepton", [lepton_bin]):
+        return True
+
+    # Rename outputs to timestamped names matching the coregistration pipeline's expectations.
+    for src_glob, dst_name in [
+        (path.join(directory, "IMG_*.pgm"),          f"lepton_{date}.pgm"),
+        (path.join(directory, "lepton_temp_*.csv"),  f"temperatures_{date}.csv"),
+    ]:
+        matches = sorted(glob(src_glob))
+        if matches:
+            try:
+                rename(matches[0], path.join(directory, dst_name))
+            except Exception as exc:
+                print(f"Could not rename {matches[0]}: {exc}")
 
     return True
 


### PR DESCRIPTION
- Replace chdir() with cwd= in subprocess.run — chdir() is process-wide and would affect other concurrently-running TTPython SQ nodes
- Increase timeout from 5s to 20s to match button_hold_camera.py
- Add stdout/stderr=DEVNULL to prevent pipe-buffer deadlock on chatty output
- Add _reset_lepton() on timeout, non-zero exit, and missing output files
- Validate .pgm and lepton_temp_*.csv actually appeared after each binary runs
- Use glob rename (IMG_*.pgm) instead of hardcoded IMG_0000.pgm
- makedirs(directory) replaces the complex fallback/chdir error-handling block that is no longer needed without chdir()