### PR TITLE
fix: battery level estimation — replace broken LiPo formula with three-path SOC manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ build/
 # Runtime config files
 lora_config.json
 runtime_config.json
+battery_state.json
+battery_state.json.tmp
 
 # IDE
 .vscode/

--- a/docs/BATTERY_ESTIMATION_PLAN.md
+++ b/docs/BATTERY_ESTIMATION_PLAN.md
@@ -152,11 +152,13 @@ Priority fallback chain:
   4. Unavailable — battery_pct=None, battery channel omitted from packets
 
 _read_ads1115_dplus() → float | None
-    Read AIN0 from ADS1115 at ±2.048V gain via board.I2C() cached singleton.
+    Read AIN0 from ADS1115 at ±2.048V gain.
+    Caches the AnalogIn instance at module scope; resets on hardware error.
     Returns voltage in V, or None if hardware absent.
 
 _read_ina260() → tuple[float, float, float] | None
-    Read voltage, current, power from INA260 via board.I2C() cached singleton.
+    Read voltage, current, power from INA260.
+    Caches the INA260 instance at module scope; resets on hardware error.
     Returns None if hardware absent.
 
 _read_wittypi_output() → tuple[float, float] | None
@@ -194,7 +196,7 @@ _save_state(state) → None
 - [x] Write `tests/test_battery_manager.py` (49 tests passing)
 - [x] Add WittyPi output-voltage fallback path (Path 3)
 - [x] Add INA260 coulomb-counting fallback path (Path 2)
-- [x] Use `board.I2C()` cached singleton to avoid I2C bus contention
+- [x] Cache ADS1115/INA260 sensor instances at module scope to avoid repeated I2C init
 - [x] Atomic state-file write (`os.replace`) to prevent JSON corruption on power loss
 - [x] Add `battery_state.json` to `.gitignore`
 - [x] Fix GPS key lookup in `initial_health_check.py` (`gps_lat`/`gps_lon`)

--- a/docs/BATTERY_ESTIMATION_PLAN.md
+++ b/docs/BATTERY_ESTIMATION_PLAN.md
@@ -2,7 +2,8 @@
 
 **GitHub issue:** #46  
 **Branch:** `feature/issue-46-battery-estimation`  
-**Date:** 2026-04-19
+**Date:** 2026-04-19  
+**Reference:** https://blog.voltaicsystems.com/reading-charge-level-of-voltaic-usb-battery-packs/
 
 ---
 
@@ -15,33 +16,41 @@ Solar panel
     │  (solar input cable, ~6–20V)
     ▼
 Voltaic V50 battery pack
-    │  (regulated output)
-    ├─ USB-C 5V  ──► WittyPi 4 USB-C input
-    └─ 6V system port (optional)
-                         │
-                    WittyPi 4
-                         │  (5V via GPIO header)
-                         ▼
-                   Raspberry Pi
+    │  (regulated 5V USB-C output)
+    │  └─ D+ pin carries ½ × cell voltage (~1.5–2.1V, varies with SOC)
+    ▼
+WittyPi 4 (USB-C input)
+    │  (5V via GPIO header)
+    ▼
+Raspberry Pi
 ```
 
 ### What WittyPi 4 can measure
 
 | Command | What it reads | Useful for SOC? |
 |---|---|---|
-| `get_input_voltage` | VIN pin (XH2.54) | **No** — reads regulated 5V or 6V, constant regardless of battery charge |
-| `get_output_voltage` | 5V rail to RPi | **No** — regulated by WittyPi DC/DC converter |
-| `get_output_current` | Current to RPi | Partial — shows load, not battery level |
+| `get_input_voltage` | VIN pin (XH2.54) | **No** — reads regulated 5V, constant regardless of charge |
+| `get_output_voltage` | 5V rail to RPi | **No** — regulated by WittyPi DC/DC |
+| `get_output_current` | Current to RPi | No — load current, not battery level |
 
-### Voltaic V50 characteristics
+### Voltaic V50 D+ signal (key finding)
 
-- **Capacity:** 50 Wh / ~13,500 mAh at 3.7V nominal cell voltage
-- **Output:** 5V USB regulated; no raw cell voltage terminal
-- **Digital interface:** None — SOC indicator is 4 LEDs only
-- **Charging input:** Solar panel (5–20V, up to ~2A) or USB
+Voltaic V25/V50/V75 battery packs output a **scaled cell voltage on the USB-C D+ data pin**:
 
-**Conclusion:** The existing LiPo formula `(V − 3.0) / 1.2 × 100` is physically wrong.
-`get_input_voltage` returns ~5.0 V at all charge levels → formula yields 166%, clamped to 100%.
+```
+D+ voltage ≈ cell_voltage / 2
+```
+
+| Battery state | Cell voltage | D+ voltage |
+|---|---|---|
+| Full | 4.2 V | ~2.10 V |
+| Empty (cutoff) | 3.0 V | ~1.50 V |
+| Observed full (empirical) | ~3.7 V | ~1.85 V |
+| Observed empty (empirical) | ~3.08 V | ~1.54 V |
+
+The theoretical range is 1.5–2.1 V. Empirical user measurements show 1.54–1.85 V, suggesting the pack's protection circuit cuts off before full cell voltage is reached. The LiPo formula applied to the reconstructed cell voltage is valid for this signal.
+
+**This eliminates the need for coulomb counting.** SOC is read directly on every boot — no accumulated drift, no state file, no power-path interruption.
 
 ---
 
@@ -49,148 +58,133 @@ Voltaic V50 battery pack
 
 | # | Problem | Severity | File |
 |---|---|---|---|
-| A | Wrong voltage model (LiPo formula on regulated 5V) | Critical | `ticktalk_main.py:1576` |
-| B | LoRa path never calls `get_wittypi_status()` — `battery_percent` absent or hardcoded | High | `tools/lora_transmit.py`, callers |
-| C | Silent omission when `batt_v == 0.0` — receiver can't distinguish 0% from unavailable | Medium | `ticktalk_main.py:1575` |
-| D | Voltage-to-percent logic duplicated inline, not shared | Low | all transmit paths |
+| A | Wrong voltage source: LiPo formula applied to regulated 5V WittyPi VIN | Critical | `ticktalk_main.py:1576` |
+| B | LoRa path never reads live battery status — `battery_percent` hardcoded or absent | High | `tools/lora_transmit.py`, callers |
+| C | Silent omission when reading fails — receiver can't distinguish 0% from unavailable | Medium | `ticktalk_main.py:1575` |
+| D | Voltage-to-percent logic inline and duplicated across transmit paths | Low | all transmit paths |
 
 ---
 
-## 3. Recommended Solution
+## 3. Solution
 
-### 3a. New hardware: Adafruit INA260 (Product #4226)
+### Primary: ADS1115 + D+ pin
 
-**Why INA260:**
-- I2C (shares existing bus with AHT20/BNO085)
-- Measures voltage AND current simultaneously
-- ±1.25 mA current resolution, ±1.25 mV voltage resolution
-- STEMMA QT connector — no soldering needed
-- Adafruit CircuitPython / Python library available (`adafruit_ina260`)
+Read the Voltaic V50's D+ pin using an **Adafruit ADS1115** 16-bit ADC over I2C.
 
-**Placement:**  
-Insert INA260 in-line on the power feed from Voltaic V50 output to WittyPi VIN or USB-C input. The INA260 passes power through its shunt resistor; current flows normally.
+**Why ADS1115 over direct GPIO:**
+- Raspberry Pi has no built-in ADC; GPIO pins are digital only
+- ADS1115 provides 16-bit resolution at ±2.048 V range → ~62.5 µV/LSB
+- Over the ~0.31 V empirical D+ span: ~4,960 usable steps (ample precision)
+- Already on I2C bus shared with AHT20 and BNO085; no new bus needed
+- Adafruit STEMMA QT — no soldering
+
+**SOC formula:**
+```python
+cell_v = d_plus_v * 2.0
+batt_pct = max(0, min(100, int((cell_v - CELL_V_MIN) / (CELL_V_MAX - CELL_V_MIN) * 100)))
+```
+
+Where `CELL_V_MIN = 3.0 V`, `CELL_V_MAX = 4.2 V`. These constants are tunable once empirical D+ readings are collected from the deployed unit.
+
+### Fallback: no hardware
+
+When ADS1115 is absent (or D+ wire not connected):
+- Return `battery_pct = None`, `battery_source = "unavailable"`
+- Omit channel `02 01` from packets — receiver treats as unknown
+- Log WittyPi VIN for cable-fault diagnostics only (do not compute SOC from it)
+
+---
+
+## 4. Hardware BOM
+
+| Component | Adafruit Product | Qty | Notes |
+|---|---|---|---|
+| ADS1115 16-bit ADC breakout | #1085 | 1 | I2C addr 0x48; STEMMA QT |
+| USB-C breakout board | #4090 | 1 | Exposes D+, D−, VBUS, GND pins |
+| STEMMA QT cable | #4210 | 1 | ADS1115 → RPi I2C header |
+| 22 AWG wire | — | ~10 cm | D+ from USB-C breakout to ADS1115 AIN0 |
 
 **Wiring:**
 ```
-Voltaic V50 5V output
+Voltaic V50 USB-C output
     │
     ▼
-INA260 Vin+  ──  shunt  ──  INA260 Vin−
-                                  │
-                             WittyPi USB-C / VIN
-INA260 SDA ──► RPi GPIO 2 (I2C1 SDA)
-INA260 SCL ──► RPi GPIO 3 (I2C1 SCL)
-INA260 GND ──► Common GND
+USB-C breakout board
+    ├─ VBUS (5V) ──► WittyPi USB-C input (power path unchanged)
+    ├─ GND ──────► Common GND
+    └─ D+ ───────► ADS1115 AIN0
+
+ADS1115
+    ├─ AIN0 ──► D+ (as above)
+    ├─ GND ───► Common GND
+    ├─ SDA ───► RPi GPIO 2 (I2C1 SDA)  [shared with AHT20, BNO085]
+    └─ SCL ───► RPi GPIO 3 (I2C1 SCL)
 ```
 
-### 3b. Coulomb counting algorithm
-
-Since the Voltaic V50 output voltage is regulated and cannot indicate SOC, we integrate current over time:
-
-```
-mAh_remaining = mAh_capacity - mAh_discharged_cumulative + mAh_recharged_cumulative
-SOC = mAh_remaining / mAh_capacity × 100
-```
-
-**State persistence:**  
-Write accumulated charge to `/var/lib/watercam/battery_state.json` on each reading. This survives reboots (the RPi is powered off between measurements by WittyPi schedule).
-
-**Known limitations:**
-- Requires initial calibration (first boot after full charge, set state to 100%)
-- Solar recharge current must also be measured (INA260 on charge path, or assume conservative 0 recharge)
-- Coulomb-counting drift accumulates over weeks; periodic full-charge reset needed
-
-**Capacity constant:**  
-`VOLTAIC_V50_MAH = 13500` (50 Wh ÷ 3.7V nominal = 13,513 mAh; round to 13500)
-
-### 3c. Fallback path (no new hardware)
-
-Without the INA260:
-- Report `battery_source = "unavailable"`
-- Transmit raw WittyPi input voltage for diagnostic purposes
-- Do NOT apply LiPo formula to regulated voltage
-- Omit battery_percent channel from packet (receiver treats as unknown)
+The USB-C breakout sits in-line on the USB-C cable from the Voltaic V50 to the WittyPi. VBUS/GND carry power as normal; D+ is tapped for ADC reading only (high-impedance, no load on the signal).
 
 ---
 
-## 4. Software Architecture
+## 5. Software Architecture
 
-### New module: `tools/battery_manager.py`
+### `tools/battery_manager.py`
 
 ```
-battery_manager
-├── get_battery_status() → dict
-│     ├── battery_pct: int | None
-│     ├── battery_source: "ina260" | "unavailable"
-│     ├── input_voltage_v: float        (raw WittyPi VIN, diagnostic)
-│     ├── current_ma: float | None      (INA260, if available)
-│     └── mah_remaining: float | None   (coulomb counter, if available)
-│
-├── _read_ina260() → (voltage_v, current_ma, power_mw) | None
-├── _update_coulomb_state(current_ma, elapsed_s) → mah_remaining
-├── _load_state() → dict                (reads battery_state.json)
-└── _save_state(state: dict) → None     (writes battery_state.json)
-```
+get_battery_status() → dict
+    battery_pct:      int | None      (0–100, or None if unavailable)
+    battery_source:   str             ("ads1115_dplus" | "unavailable")
+    cell_voltage_v:   float | None    (reconstructed cell voltage, V)
+    d_plus_v:         float | None    (raw D+ reading, V)
 
-**State file schema** (`/var/lib/watercam/battery_state.json`):
-```json
-{
-  "mah_discharged": 1234.5,
-  "mah_recharged": 56.2,
-  "last_updated_utc": "2026-04-19T12:00:00Z",
-  "calibrated": true
-}
+_read_ads1115_dplus() → float | None
+    Read AIN0 from ADS1115 at ±2.048V gain.
+    Returns voltage in V, or None if hardware absent.
+
+_cell_voltage_to_pct(cell_v: float) → int
+    Apply LiPo formula clamped [0, 100].
+
+_log_wittypi_vin_diagnostic() → None
+    Log WittyPi get_input_voltage for cable-fault detection only.
 ```
 
 ### Changes to existing files
 
 | File | Change |
 |---|---|
-| `tools/wittypi_control.py` | Add `get_input_voltage_raw()` wrapper — return raw voltage only, no percent conversion |
-| `ticktalk_main.py` (IP path, line ~1573) | Replace inline formula with `battery_manager.get_battery_status()` |
-| `ticktalk_main.py` (LoRa data collect, line ~245) | Wire `battery_manager.get_battery_status()` into `data` dict |
-| `tools/lora_transmit.py` | Read `battery_percent` from `data` as before; add defensive check for `None` |
-| channel encoding (all paths) | Skip `02 01` channel if `battery_pct is None`; add comment explaining why |
+| `ticktalk_main.py` (×2 LoRa data blocks) | Replace WittyPi battery_voltage block with `battery_manager.get_battery_status()` |
+| `ticktalk_main.py` (IP uplink, ~line 1573) | Replace inline LiPo formula with `battery_manager.get_battery_status()` |
+| `tools/lora_transmit.py` | Guard `battery_percent` with `is not None` check (already done) |
+| `tools/lora_handler_concurrent.py` | Same None guard (already done) |
 
 ---
 
-## 5. Implementation Steps
+## 6. Implementation Steps
 
 - [x] Create GitHub issue #46
 - [x] Create branch `feature/issue-46-battery-estimation`
-- [ ] **Step 1** — Write `tools/battery_manager.py`
-  - INA260 read path (with `try/except` for hardware-not-present)
-  - Coulomb counting with persistent state file
-  - Fallback that returns `None` percent with source tag
-- [ ] **Step 2** — Fix IP uplink path in `ticktalk_main.py`
-  - Replace inline LiPo formula with `battery_manager.get_battery_status()`
-  - Handle `battery_pct = None` explicitly
-- [ ] **Step 3** — Wire LoRa data collection path
-  - Add `battery_manager.get_battery_status()` call in the WittyPi data block (~line 245)
-  - Store result in `data['battery_percent']` and `data['battery_source']`
-- [ ] **Step 4** — Update `lora_transmit.py` to skip channel if percent is None
-- [ ] **Step 5** — Tests
-  - Unit tests for coulomb counting math
-  - Unit tests for INA260 fallback (mock hardware absent)
-  - Integration test for packet encoding with None battery
-- [ ] **Step 6** — Update `docs/KNOWN_ISSUES.md` (close battery entry)
-- [ ] **Step 7** — Hardware procurement note in README
+- [x] Write `tools/battery_manager.py` (initial INA260 version)
+- [x] Fix IP uplink and LoRa paths in `ticktalk_main.py`
+- [x] Fix `lora_transmit.py` and `lora_handler_concurrent.py` None guard
+- [x] Write `tests/test_battery_manager.py` (14 tests passing)
+- [x] Revise `battery_manager.py` to use ADS1115 + D+ (replaces INA260/coulomb counting)
+- [ ] Deploy hardware and collect empirical D+ readings to tune `CELL_V_MIN`/`CELL_V_MAX`
+- [ ] Update `docs/KNOWN_ISSUES.md`
 
 ---
 
-## 6. Out of Scope
+## 7. Out of Scope
 
-- Measuring solar recharge current (would require second INA260 on charge path — future work)
-- Automatic full-charge calibration trigger (requires detecting when Voltaic V50 is at 100%; no digital signal available — future work)
-- Replacing Voltaic V50 with a pack that has a digital fuel gauge interface
+- Measuring solar recharge current (D+ reads instantaneous SOC; recharge is implicit)
+- Distinguishing charging vs discharging state (would need D− or CC pin monitoring)
+- Automatic wake-on-low-battery (WittyPi low-voltage threshold handles this via VIN)
 
 ---
 
-## 7. Acceptance Criteria
+## 8. Acceptance Criteria
 
-1. `battery_pct` in transmitted packets reflects actual coulomb-counted SOC when INA260 is present
-2. When INA260 is absent, battery channel is omitted from packet (not silently wrong)
+1. `battery_pct` in packets reflects D+ derived cell SOC when ADS1115 is present
+2. When ADS1115 absent, battery channel omitted from packet (not silently wrong)
 3. `battery_source` field always present in status dict
-4. No LiPo voltage formula applied to regulated supply voltage anywhere in codebase
-5. LoRa path transmits live `battery_percent` from `battery_manager`, not hardcoded value
-6. All tests pass; INA260 absence does not crash the system
+4. No LiPo formula applied to regulated WittyPi VIN voltage anywhere in codebase
+5. LoRa and IP paths both use `battery_manager.get_battery_status()`
+6. All tests pass; ADS1115 absence does not crash the system

--- a/docs/BATTERY_ESTIMATION_PLAN.md
+++ b/docs/BATTERY_ESTIMATION_PLAN.md
@@ -86,12 +86,16 @@ batt_pct = max(0, min(100, int((cell_v - CELL_V_MIN) / (CELL_V_MAX - CELL_V_MIN)
 
 Where `CELL_V_MIN = 3.0 V`, `CELL_V_MAX = 4.2 V`. These constants are tunable once empirical D+ readings are collected from the deployed unit.
 
-### Fallback: no hardware
+### Fallback chain when ADS1115 is absent
 
-When ADS1115 is absent (or D+ wire not connected):
-- Return `battery_pct = None`, `battery_source = "unavailable"`
-- Omit channel `02 01` from packets — receiver treats as unknown
-- Log WittyPi VIN for cable-fault diagnostics only (do not compute SOC from it)
+The shipped `battery_manager` does not immediately declare unavailable when ADS1115/D+ is absent. It tries each path in order:
+
+1. **ADS1115 D+** (preferred) — direct voltage reading, no drift, no state file
+2. **INA260 coulomb counting** — accurate fallback; accumulated mAh persisted to `battery_state.json`
+3. **WittyPi output voltage** — coarse estimate from the 5V rail sag; no extra hardware required
+4. **Unavailable** — `battery_pct = None`, `battery_source = "unavailable"`; channel `02 01` omitted from packets so the receiver treats battery state as unknown
+
+WittyPi VIN (`get_input_voltage`) is **not** used for SOC — it reads a regulated 5V rail and is logged only as a cable-fault diagnostic.
 
 ---
 

--- a/docs/BATTERY_ESTIMATION_PLAN.md
+++ b/docs/BATTERY_ESTIMATION_PLAN.md
@@ -30,7 +30,7 @@ Raspberry Pi
 | Command | What it reads | Useful for SOC? |
 |---|---|---|
 | `get_input_voltage` | VIN pin (XH2.54) | **No** — reads regulated 5V, constant regardless of charge |
-| `get_output_voltage` | 5V rail to RPi | **No** — regulated by WittyPi DC/DC |
+| `get_output_voltage` | 5V rail to RPi | **Limited / fallback only** — regulated by WittyPi DC/DC, but rail sag under load is a coarse indicator when no better signal exists (Path 3) |
 | `get_output_current` | Current to RPi | No — load current, not battery level |
 
 ### Voltaic V50 D+ signal (key finding)
@@ -50,7 +50,7 @@ D+ voltage ≈ cell_voltage / 2
 
 The theoretical range is 1.5–2.1 V. Empirical user measurements show 1.54–1.85 V, suggesting the pack's protection circuit cuts off before full cell voltage is reached. The LiPo formula applied to the reconstructed cell voltage is valid for this signal.
 
-**This eliminates the need for coulomb counting.** SOC is read directly on every boot — no accumulated drift, no state file, no power-path interruption.
+The ADS1115 D+ path is the **primary** SOC source: no accumulated drift, no state file, no power-path interruption. The shipped `battery_manager` retains two fallback paths — INA260 coulomb counting (which does use a persisted state file) and WittyPi output voltage — so the system degrades gracefully when the preferred hardware is absent.
 
 ---
 

--- a/docs/BATTERY_ESTIMATION_PLAN.md
+++ b/docs/BATTERY_ESTIMATION_PLAN.md
@@ -132,19 +132,41 @@ The USB-C breakout sits in-line on the USB-C cable from the Voltaic V50 to the W
 ```
 get_battery_status() → dict
     battery_pct:      int | None      (0–100, or None if unavailable)
-    battery_source:   str             ("ads1115_dplus" | "unavailable")
-    cell_voltage_v:   float | None    (reconstructed cell voltage, V)
-    d_plus_v:         float | None    (raw D+ reading, V)
+    battery_source:   str             ("ads1115_dplus" | "ina260" |
+                                       "wittypi_output" | "unavailable")
+    cell_voltage_v:   float | None    (reconstructed cell voltage, V; ADS1115 only)
+    d_plus_v:         float | None    (raw D+ reading, V; ADS1115 only)
+    current_ma:       float | None    (instantaneous draw, mA; INA260 only)
+    mah_remaining:    float | None    (coulomb-counted charge, mAh; INA260 only)
+    output_voltage_v: float | None    (WittyPi 5V rail reading, V; WittyPi path only)
+    output_current_a: float | None    (WittyPi output current, A; WittyPi path only)
+
+Priority fallback chain:
+  1. ADS1115 D+ (preferred — no drift, no state file)
+  2. INA260 coulomb counting (fallback — accurate, drifts; state in battery_state.json)
+  3. WittyPi output voltage (rough estimate — no extra hardware)
+  4. Unavailable — battery_pct=None, battery channel omitted from packets
 
 _read_ads1115_dplus() → float | None
-    Read AIN0 from ADS1115 at ±2.048V gain.
+    Read AIN0 from ADS1115 at ±2.048V gain via board.I2C() cached singleton.
     Returns voltage in V, or None if hardware absent.
+
+_read_ina260() → tuple[float, float, float] | None
+    Read voltage, current, power from INA260 via board.I2C() cached singleton.
+    Returns None if hardware absent.
+
+_read_wittypi_output() → tuple[float, float] | None
+    Read internal_voltage and internal_current from WittyPi 4.
+    Returns None if unavailable.
 
 _cell_voltage_to_pct(cell_v: float) → int
     Apply LiPo formula clamped [0, 100].
 
-_log_wittypi_vin_diagnostic() → None
-    Log WittyPi get_input_voltage for cable-fault detection only.
+_wittypi_output_to_pct(output_v: float) → int
+    Linear mapping between WITTYPI_OUTPUT_V_EMPTY and WITTYPI_OUTPUT_V_FULL.
+
+_save_state(state) → None
+    Atomic write (temp file + os.replace) to prevent JSON corruption on power loss.
 ```
 
 ### Changes to existing files
@@ -165,8 +187,13 @@ _log_wittypi_vin_diagnostic() → None
 - [x] Write `tools/battery_manager.py` (initial INA260 version)
 - [x] Fix IP uplink and LoRa paths in `ticktalk_main.py`
 - [x] Fix `lora_transmit.py` and `lora_handler_concurrent.py` None guard
-- [x] Write `tests/test_battery_manager.py` (14 tests passing)
-- [x] Revise `battery_manager.py` to use ADS1115 + D+ (replaces INA260/coulomb counting)
+- [x] Write `tests/test_battery_manager.py` (49 tests passing)
+- [x] Add WittyPi output-voltage fallback path (Path 3)
+- [x] Add INA260 coulomb-counting fallback path (Path 2)
+- [x] Use `board.I2C()` cached singleton to avoid I2C bus contention
+- [x] Atomic state-file write (`os.replace`) to prevent JSON corruption on power loss
+- [x] Add `battery_state.json` to `.gitignore`
+- [x] Fix GPS key lookup in `initial_health_check.py` (`gps_lat`/`gps_lon`)
 - [ ] Deploy hardware and collect empirical D+ readings to tune `CELL_V_MIN`/`CELL_V_MAX`
 - [ ] Update `docs/KNOWN_ISSUES.md`
 
@@ -183,8 +210,11 @@ _log_wittypi_vin_diagnostic() → None
 ## 8. Acceptance Criteria
 
 1. `battery_pct` in packets reflects D+ derived cell SOC when ADS1115 is present
-2. When ADS1115 absent, battery channel omitted from packet (not silently wrong)
-3. `battery_source` field always present in status dict
-4. No LiPo formula applied to regulated WittyPi VIN voltage anywhere in codebase
-5. LoRa and IP paths both use `battery_manager.get_battery_status()`
-6. All tests pass; ADS1115 absence does not crash the system
+2. Falls back to INA260 coulomb counting when ADS1115 absent
+3. Falls back to WittyPi output voltage when both ADS1115 and INA260 absent
+4. When all paths unavailable, battery channel omitted from packet (not silently wrong)
+5. `battery_source` field always present in status dict
+6. No LiPo formula applied to regulated WittyPi VIN voltage anywhere in codebase
+7. LoRa and IP paths both use `battery_manager.get_battery_status()`
+8. All tests pass; absence of any hardware does not crash the system
+9. State file writes are atomic; JSON is never left corrupt after power loss

--- a/docs/BATTERY_ESTIMATION_PLAN.md
+++ b/docs/BATTERY_ESTIMATION_PLAN.md
@@ -1,0 +1,196 @@
+# Battery Level Estimation — Design & Implementation Plan
+
+**GitHub issue:** #46  
+**Branch:** `feature/issue-46-battery-estimation`  
+**Date:** 2026-04-19
+
+---
+
+## 1. Hardware Context
+
+### Power chain
+
+```
+Solar panel
+    │  (solar input cable, ~6–20V)
+    ▼
+Voltaic V50 battery pack
+    │  (regulated output)
+    ├─ USB-C 5V  ──► WittyPi 4 USB-C input
+    └─ 6V system port (optional)
+                         │
+                    WittyPi 4
+                         │  (5V via GPIO header)
+                         ▼
+                   Raspberry Pi
+```
+
+### What WittyPi 4 can measure
+
+| Command | What it reads | Useful for SOC? |
+|---|---|---|
+| `get_input_voltage` | VIN pin (XH2.54) | **No** — reads regulated 5V or 6V, constant regardless of battery charge |
+| `get_output_voltage` | 5V rail to RPi | **No** — regulated by WittyPi DC/DC converter |
+| `get_output_current` | Current to RPi | Partial — shows load, not battery level |
+
+### Voltaic V50 characteristics
+
+- **Capacity:** 50 Wh / ~13,500 mAh at 3.7V nominal cell voltage
+- **Output:** 5V USB regulated; no raw cell voltage terminal
+- **Digital interface:** None — SOC indicator is 4 LEDs only
+- **Charging input:** Solar panel (5–20V, up to ~2A) or USB
+
+**Conclusion:** The existing LiPo formula `(V − 3.0) / 1.2 × 100` is physically wrong.
+`get_input_voltage` returns ~5.0 V at all charge levels → formula yields 166%, clamped to 100%.
+
+---
+
+## 2. Problems to Fix
+
+| # | Problem | Severity | File |
+|---|---|---|---|
+| A | Wrong voltage model (LiPo formula on regulated 5V) | Critical | `ticktalk_main.py:1576` |
+| B | LoRa path never calls `get_wittypi_status()` — `battery_percent` absent or hardcoded | High | `tools/lora_transmit.py`, callers |
+| C | Silent omission when `batt_v == 0.0` — receiver can't distinguish 0% from unavailable | Medium | `ticktalk_main.py:1575` |
+| D | Voltage-to-percent logic duplicated inline, not shared | Low | all transmit paths |
+
+---
+
+## 3. Recommended Solution
+
+### 3a. New hardware: Adafruit INA260 (Product #4226)
+
+**Why INA260:**
+- I2C (shares existing bus with AHT20/BNO085)
+- Measures voltage AND current simultaneously
+- ±1.25 mA current resolution, ±1.25 mV voltage resolution
+- STEMMA QT connector — no soldering needed
+- Adafruit CircuitPython / Python library available (`adafruit_ina260`)
+
+**Placement:**  
+Insert INA260 in-line on the power feed from Voltaic V50 output to WittyPi VIN or USB-C input. The INA260 passes power through its shunt resistor; current flows normally.
+
+**Wiring:**
+```
+Voltaic V50 5V output
+    │
+    ▼
+INA260 Vin+  ──  shunt  ──  INA260 Vin−
+                                  │
+                             WittyPi USB-C / VIN
+INA260 SDA ──► RPi GPIO 2 (I2C1 SDA)
+INA260 SCL ──► RPi GPIO 3 (I2C1 SCL)
+INA260 GND ──► Common GND
+```
+
+### 3b. Coulomb counting algorithm
+
+Since the Voltaic V50 output voltage is regulated and cannot indicate SOC, we integrate current over time:
+
+```
+mAh_remaining = mAh_capacity - mAh_discharged_cumulative + mAh_recharged_cumulative
+SOC = mAh_remaining / mAh_capacity × 100
+```
+
+**State persistence:**  
+Write accumulated charge to `/var/lib/watercam/battery_state.json` on each reading. This survives reboots (the RPi is powered off between measurements by WittyPi schedule).
+
+**Known limitations:**
+- Requires initial calibration (first boot after full charge, set state to 100%)
+- Solar recharge current must also be measured (INA260 on charge path, or assume conservative 0 recharge)
+- Coulomb-counting drift accumulates over weeks; periodic full-charge reset needed
+
+**Capacity constant:**  
+`VOLTAIC_V50_MAH = 13500` (50 Wh ÷ 3.7V nominal = 13,513 mAh; round to 13500)
+
+### 3c. Fallback path (no new hardware)
+
+Without the INA260:
+- Report `battery_source = "unavailable"`
+- Transmit raw WittyPi input voltage for diagnostic purposes
+- Do NOT apply LiPo formula to regulated voltage
+- Omit battery_percent channel from packet (receiver treats as unknown)
+
+---
+
+## 4. Software Architecture
+
+### New module: `tools/battery_manager.py`
+
+```
+battery_manager
+├── get_battery_status() → dict
+│     ├── battery_pct: int | None
+│     ├── battery_source: "ina260" | "unavailable"
+│     ├── input_voltage_v: float        (raw WittyPi VIN, diagnostic)
+│     ├── current_ma: float | None      (INA260, if available)
+│     └── mah_remaining: float | None   (coulomb counter, if available)
+│
+├── _read_ina260() → (voltage_v, current_ma, power_mw) | None
+├── _update_coulomb_state(current_ma, elapsed_s) → mah_remaining
+├── _load_state() → dict                (reads battery_state.json)
+└── _save_state(state: dict) → None     (writes battery_state.json)
+```
+
+**State file schema** (`/var/lib/watercam/battery_state.json`):
+```json
+{
+  "mah_discharged": 1234.5,
+  "mah_recharged": 56.2,
+  "last_updated_utc": "2026-04-19T12:00:00Z",
+  "calibrated": true
+}
+```
+
+### Changes to existing files
+
+| File | Change |
+|---|---|
+| `tools/wittypi_control.py` | Add `get_input_voltage_raw()` wrapper — return raw voltage only, no percent conversion |
+| `ticktalk_main.py` (IP path, line ~1573) | Replace inline formula with `battery_manager.get_battery_status()` |
+| `ticktalk_main.py` (LoRa data collect, line ~245) | Wire `battery_manager.get_battery_status()` into `data` dict |
+| `tools/lora_transmit.py` | Read `battery_percent` from `data` as before; add defensive check for `None` |
+| channel encoding (all paths) | Skip `02 01` channel if `battery_pct is None`; add comment explaining why |
+
+---
+
+## 5. Implementation Steps
+
+- [x] Create GitHub issue #46
+- [x] Create branch `feature/issue-46-battery-estimation`
+- [ ] **Step 1** — Write `tools/battery_manager.py`
+  - INA260 read path (with `try/except` for hardware-not-present)
+  - Coulomb counting with persistent state file
+  - Fallback that returns `None` percent with source tag
+- [ ] **Step 2** — Fix IP uplink path in `ticktalk_main.py`
+  - Replace inline LiPo formula with `battery_manager.get_battery_status()`
+  - Handle `battery_pct = None` explicitly
+- [ ] **Step 3** — Wire LoRa data collection path
+  - Add `battery_manager.get_battery_status()` call in the WittyPi data block (~line 245)
+  - Store result in `data['battery_percent']` and `data['battery_source']`
+- [ ] **Step 4** — Update `lora_transmit.py` to skip channel if percent is None
+- [ ] **Step 5** — Tests
+  - Unit tests for coulomb counting math
+  - Unit tests for INA260 fallback (mock hardware absent)
+  - Integration test for packet encoding with None battery
+- [ ] **Step 6** — Update `docs/KNOWN_ISSUES.md` (close battery entry)
+- [ ] **Step 7** — Hardware procurement note in README
+
+---
+
+## 6. Out of Scope
+
+- Measuring solar recharge current (would require second INA260 on charge path — future work)
+- Automatic full-charge calibration trigger (requires detecting when Voltaic V50 is at 100%; no digital signal available — future work)
+- Replacing Voltaic V50 with a pack that has a digital fuel gauge interface
+
+---
+
+## 7. Acceptance Criteria
+
+1. `battery_pct` in transmitted packets reflects actual coulomb-counted SOC when INA260 is present
+2. When INA260 is absent, battery channel is omitted from packet (not silently wrong)
+3. `battery_source` field always present in status dict
+4. No LiPo voltage formula applied to regulated supply voltage anywhere in codebase
+5. LoRa path transmits live `battery_percent` from `battery_manager`, not hardcoded value
+6. All tests pass; INA260 absence does not crash the system

--- a/tests/test_battery_manager.py
+++ b/tests/test_battery_manager.py
@@ -1,0 +1,150 @@
+"""Tests for tools/battery_manager.py"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone, timedelta
+
+
+class TestCoulombCounting(unittest.TestCase):
+
+    def setUp(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+        import tools.battery_manager as bm
+        self.bm = bm
+
+    def test_full_capacity_on_fresh_state(self):
+        state = self.bm._load_state.__func__ if hasattr(self.bm._load_state, "__func__") else None
+        # _load_state with missing file returns full capacity
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            state = self.bm._load_state()
+        self.assertAlmostEqual(state["mah_remaining"], self.bm.VOLTAIC_V50_MAH)
+        self.assertFalse(state["calibrated"])
+
+    def test_discharge_reduces_remaining(self):
+        state = {"mah_remaining": 13500.0, "last_updated_utc": None, "calibrated": True}
+        # 1000 mA draw for 1 hour = 1000 mAh consumed
+        remaining = self.bm._update_coulomb_state(state, current_ma=1000.0, elapsed_s=3600.0)
+        self.assertAlmostEqual(remaining, 12500.0, places=1)
+
+    def test_discharge_clamps_to_zero(self):
+        state = {"mah_remaining": 10.0, "last_updated_utc": None, "calibrated": True}
+        remaining = self.bm._update_coulomb_state(state, current_ma=5000.0, elapsed_s=3600.0)
+        self.assertEqual(remaining, 0.0)
+
+    def test_zero_elapsed_no_change(self):
+        state = {"mah_remaining": 8000.0, "last_updated_utc": None, "calibrated": True}
+        remaining = self.bm._update_coulomb_state(state, current_ma=1000.0, elapsed_s=0.0)
+        self.assertAlmostEqual(remaining, 8000.0)
+
+    def test_soc_percent_from_mah(self):
+        mah = self.bm.VOLTAIC_V50_MAH * 0.75
+        pct = max(0, min(100, int(mah / self.bm.VOLTAIC_V50_MAH * 100)))
+        self.assertEqual(pct, 75)
+
+    def test_elapsed_seconds_valid_timestamp(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        elapsed = self.bm._elapsed_seconds_since(past)
+        self.assertGreater(elapsed, 3500)
+        self.assertLess(elapsed, 3700)
+
+    def test_elapsed_seconds_none_returns_zero(self):
+        self.assertEqual(self.bm._elapsed_seconds_since(None), 0.0)
+
+    def test_elapsed_seconds_bad_string_returns_zero(self):
+        self.assertEqual(self.bm._elapsed_seconds_since("not-a-date"), 0.0)
+
+
+class TestStateFile(unittest.TestCase):
+
+    def setUp(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+        import tools.battery_manager as bm
+        self.bm = bm
+
+    def test_save_and_load_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_state_file = os.path.join(tmpdir, "battery_state.json")
+            with patch.object(self.bm, "STATE_FILE", test_state_file):
+                state_in = {"mah_remaining": 9876.5, "calibrated": True, "last_updated_utc": "2026-01-01T00:00:00+00:00"}
+                self.bm._save_state(state_in)
+                state_out = self.bm._load_state()
+            self.assertAlmostEqual(state_out["mah_remaining"], 9876.5)
+            self.assertTrue(state_out["calibrated"])
+
+    def test_load_missing_file_returns_defaults(self):
+        with patch.object(self.bm, "STATE_FILE", "/nonexistent/path/battery_state.json"):
+            state = self.bm._load_state()
+        self.assertAlmostEqual(state["mah_remaining"], self.bm.VOLTAIC_V50_MAH)
+
+
+class TestGetBatteryStatusFallback(unittest.TestCase):
+    """When INA260 hardware is absent, get_battery_status() must return unavailable."""
+
+    def setUp(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+        import tools.battery_manager as bm
+        self.bm = bm
+
+    def test_no_hardware_returns_none_pct(self):
+        with patch.object(self.bm, "_read_ina260", return_value=None):
+            with patch.object(self.bm, "_log_wittypi_vin_diagnostic"):
+                result = self.bm.get_battery_status()
+        self.assertIsNone(result["battery_pct"])
+        self.assertEqual(result["battery_source"], "unavailable")
+
+    def test_ina260_present_returns_pct(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_state_file = os.path.join(tmpdir, "battery_state.json")
+            # Seed state at 50%
+            seed = {"mah_remaining": self.bm.VOLTAIC_V50_MAH * 0.5,
+                    "calibrated": True,
+                    "last_updated_utc": None}
+            with open(test_state_file, "w") as f:
+                json.dump(seed, f)
+
+            with patch.object(self.bm, "_read_ina260", return_value=(5.1, 500.0, 2550.0)):
+                with patch.object(self.bm, "STATE_FILE", test_state_file):
+                    result = self.bm.get_battery_status()
+
+        self.assertEqual(result["battery_source"], "ina260")
+        self.assertIsNotNone(result["battery_pct"])
+        self.assertGreaterEqual(result["battery_pct"], 0)
+        self.assertLessEqual(result["battery_pct"], 100)
+
+
+class TestLoRaPacketEncoding(unittest.TestCase):
+    """Verify battery_percent=None is skipped in lora_transmit.compressed_encoding."""
+
+    def setUp(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+        # lora_transmit.py imports serial at module level; stub it out
+        serial_mock = MagicMock()
+        sys.modules.setdefault("serial", serial_mock)
+
+    def test_none_battery_excluded_from_packet(self):
+        import importlib
+        import tools.lora_transmit as lt
+        importlib.reload(lt)
+        data = {"timestamp": 1000000, "temperature_celsius": 20.0, "battery_percent": None}
+        packet = lt.compressed_encoding(data)
+        # Channel 0x02 0x01 must not appear
+        self.assertNotIn("0201", packet.hex())
+
+    def test_valid_battery_included_in_packet(self):
+        import importlib
+        import tools.lora_transmit as lt
+        importlib.reload(lt)
+        data = {"timestamp": 1000000, "battery_percent": 75}
+        packet = lt.compressed_encoding(data)
+        self.assertIn("0201", packet.hex())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_battery_manager.py
+++ b/tests/test_battery_manager.py
@@ -175,6 +175,58 @@ class TestINA260Path(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# WittyPi output-voltage path
+# ---------------------------------------------------------------------------
+
+class TestWittyPiOutputPath(unittest.TestCase):
+
+    def _status(self, output_v, output_a=0.5):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+            with patch.object(bm, "_read_ina260", return_value=None):
+                with patch.object(bm, "_read_wittypi_output", return_value=(output_v, output_a)):
+                    return bm.get_battery_status()
+
+    def test_source_tag(self):
+        self.assertEqual(self._status(5.05)["battery_source"], "wittypi_output")
+
+    def test_full_voltage_returns_100(self):
+        self.assertEqual(self._status(bm.WITTYPI_OUTPUT_V_FULL)["battery_pct"], 100)
+
+    def test_empty_voltage_returns_0(self):
+        self.assertEqual(self._status(bm.WITTYPI_OUTPUT_V_EMPTY)["battery_pct"], 0)
+
+    def test_midpoint(self):
+        mid_v = (bm.WITTYPI_OUTPUT_V_FULL + bm.WITTYPI_OUTPUT_V_EMPTY) / 2
+        pct = self._status(mid_v)["battery_pct"]
+        self.assertEqual(pct, 50)
+
+    def test_above_full_clamps_to_100(self):
+        self.assertEqual(self._status(6.0)["battery_pct"], 100)
+
+    def test_below_empty_clamps_to_0(self):
+        self.assertEqual(self._status(3.0)["battery_pct"], 0)
+
+    def test_output_voltage_returned(self):
+        result = self._status(5.02)
+        self.assertAlmostEqual(result["output_voltage_v"], 5.02, places=2)
+
+    def test_output_current_returned(self):
+        result = self._status(5.02, output_a=0.75)
+        self.assertAlmostEqual(result["output_current_a"], 0.75, places=2)
+
+    def test_ads1115_fields_none(self):
+        result = self._status(5.02)
+        self.assertIsNone(result["d_plus_v"])
+        self.assertIsNone(result["cell_voltage_v"])
+
+    def test_ina260_fields_none(self):
+        result = self._status(5.02)
+        self.assertIsNone(result["current_ma"])
+        self.assertIsNone(result["mah_remaining"])
+
+
+
+# ---------------------------------------------------------------------------
 # Fallback chain
 # ---------------------------------------------------------------------------
 
@@ -183,6 +235,12 @@ class TestFallbackChain(unittest.TestCase):
     def test_ads1115_takes_priority_over_ina260(self):
         with patch.object(bm, "_read_ads1115_dplus", return_value=1.80):
             with patch.object(bm, "_read_ina260", return_value=(5.1, 500.0, 2550.0)):
+                result = bm.get_battery_status()
+        self.assertEqual(result["battery_source"], "ads1115_dplus")
+
+    def test_ads1115_takes_priority_over_wittypi(self):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=1.80):
+            with patch.object(bm, "_read_wittypi_output", return_value=(5.05, 0.5)):
                 result = bm.get_battery_status()
         self.assertEqual(result["battery_source"], "ads1115_dplus")
 
@@ -195,10 +253,27 @@ class TestFallbackChain(unittest.TestCase):
                         result = bm.get_battery_status()
         self.assertEqual(result["battery_source"], "ina260")
 
-    def test_unavailable_when_both_absent(self):
+    def test_ina260_takes_priority_over_wittypi(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = os.path.join(tmpdir, "s.json")
+            with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+                with patch.object(bm, "_read_ina260", return_value=(5.1, 500.0, 2550.0)):
+                    with patch.object(bm, "_read_wittypi_output", return_value=(5.05, 0.5)):
+                        with patch.object(bm, "STATE_FILE", state_file):
+                            result = bm.get_battery_status()
+        self.assertEqual(result["battery_source"], "ina260")
+
+    def test_wittypi_used_when_ads1115_and_ina260_absent(self):
         with patch.object(bm, "_read_ads1115_dplus", return_value=None):
             with patch.object(bm, "_read_ina260", return_value=None):
-                with patch.object(bm, "_log_wittypi_vin_diagnostic"):
+                with patch.object(bm, "_read_wittypi_output", return_value=(5.05, 0.5)):
+                    result = bm.get_battery_status()
+        self.assertEqual(result["battery_source"], "wittypi_output")
+
+    def test_unavailable_when_all_absent(self):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+            with patch.object(bm, "_read_ina260", return_value=None):
+                with patch.object(bm, "_read_wittypi_output", return_value=None):
                     result = bm.get_battery_status()
         self.assertIsNone(result["battery_pct"])
         self.assertEqual(result["battery_source"], "unavailable")
@@ -206,7 +281,7 @@ class TestFallbackChain(unittest.TestCase):
     def test_unavailable_does_not_raise(self):
         with patch.object(bm, "_read_ads1115_dplus", return_value=None):
             with patch.object(bm, "_read_ina260", return_value=None):
-                with patch.object(bm, "_log_wittypi_vin_diagnostic"):
+                with patch.object(bm, "_read_wittypi_output", return_value=None):
                     try:
                         bm.get_battery_status()
                     except Exception as e:

--- a/tests/test_battery_manager.py
+++ b/tests/test_battery_manager.py
@@ -1,13 +1,20 @@
-"""Tests for tools/battery_manager.py (ADS1115 + D+ pin SOC estimation)."""
+"""Tests for tools/battery_manager.py (ADS1115 D+ and INA260 coulomb paths)."""
 
+import json
 import os
 import sys
+import tempfile
 import unittest
+from datetime import datetime, timezone, timedelta
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import tools.battery_manager as bm
 
+
+# ---------------------------------------------------------------------------
+# ADS1115 / D+ path
+# ---------------------------------------------------------------------------
 
 class TestCellVoltageToPct(unittest.TestCase):
 
@@ -28,115 +35,212 @@ class TestCellVoltageToPct(unittest.TestCase):
         self.assertEqual(bm._cell_voltage_to_pct(1.0), 0)
 
     def test_empirical_observed_full(self):
-        # Voltaic blog reports ~1.85V D+ at observed full → cell ~3.7V → ~58%
-        d_plus = 1.85
-        cell_v = d_plus * 2.0
-        pct = bm._cell_voltage_to_pct(cell_v)
+        # Voltaic blog: ~1.85V D+ at observed full → cell ~3.7V → ~58%
+        pct = bm._cell_voltage_to_pct(1.85 * 2.0)
         self.assertGreater(pct, 50)
         self.assertLess(pct, 75)
 
     def test_empirical_observed_empty(self):
-        # Voltaic blog reports ~1.54V D+ at observed empty → cell ~3.08V → ~7%
-        d_plus = 1.54
-        cell_v = d_plus * 2.0
-        pct = bm._cell_voltage_to_pct(cell_v)
+        # Voltaic blog: ~1.54V D+ at observed empty → cell ~3.08V → ~7%
+        pct = bm._cell_voltage_to_pct(1.54 * 2.0)
         self.assertGreaterEqual(pct, 0)
         self.assertLess(pct, 15)
 
     def test_returns_int(self):
-        result = bm._cell_voltage_to_pct(3.6)
-        self.assertIsInstance(result, int)
+        self.assertIsInstance(bm._cell_voltage_to_pct(3.6), int)
 
 
-class TestGetBatteryStatusFallback(unittest.TestCase):
-    """When ADS1115 is absent, get_battery_status() returns unavailable."""
+class TestADS1115Path(unittest.TestCase):
 
-    def test_no_hardware_returns_none_pct(self):
-        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
-            with patch.object(bm, "_log_wittypi_vin_diagnostic"):
-                result = bm.get_battery_status()
-        self.assertIsNone(result["battery_pct"])
-        self.assertEqual(result["battery_source"], "unavailable")
-        self.assertIsNone(result["cell_voltage_v"])
-        self.assertIsNone(result["d_plus_v"])
-
-    def test_no_hardware_does_not_raise(self):
-        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
-            with patch.object(bm, "_log_wittypi_vin_diagnostic"):
-                try:
-                    bm.get_battery_status()
-                except Exception as e:
-                    self.fail(f"get_battery_status raised unexpectedly: {e}")
-
-
-class TestGetBatteryStatusWithHardware(unittest.TestCase):
-    """When ADS1115 reads a valid D+ voltage, SOC is computed correctly."""
-
-    def _run_with_dplus(self, d_plus_v):
+    def _status(self, d_plus_v):
         with patch.object(bm, "_read_ads1115_dplus", return_value=d_plus_v):
             return bm.get_battery_status()
 
     def test_source_tag(self):
-        result = self._run_with_dplus(1.85)
-        self.assertEqual(result["battery_source"], "ads1115_dplus")
+        self.assertEqual(self._status(1.85)["battery_source"], "ads1115_dplus")
 
-    def test_d_plus_v_returned(self):
-        result = self._run_with_dplus(1.75)
-        self.assertAlmostEqual(result["d_plus_v"], 1.75, places=3)
+    def test_d_plus_returned(self):
+        self.assertAlmostEqual(self._status(1.75)["d_plus_v"], 1.75, places=3)
 
     def test_cell_voltage_is_double_dplus(self):
-        result = self._run_with_dplus(1.85)
-        self.assertAlmostEqual(result["cell_voltage_v"], 3.70, places=2)
+        self.assertAlmostEqual(self._status(1.85)["cell_voltage_v"], 3.70, places=2)
 
     def test_full_charge(self):
-        # D+ = 2.1V → cell = 4.2V → 100%
-        result = self._run_with_dplus(2.1)
-        self.assertEqual(result["battery_pct"], 100)
+        self.assertEqual(self._status(2.1)["battery_pct"], 100)
 
     def test_empty(self):
-        # D+ = 1.5V → cell = 3.0V → 0%
-        result = self._run_with_dplus(1.5)
-        self.assertEqual(result["battery_pct"], 0)
+        self.assertEqual(self._status(1.5)["battery_pct"], 0)
 
     def test_pct_in_range(self):
-        result = self._run_with_dplus(1.75)
-        self.assertGreaterEqual(result["battery_pct"], 0)
-        self.assertLessEqual(result["battery_pct"], 100)
+        pct = self._status(1.75)["battery_pct"]
+        self.assertGreaterEqual(pct, 0)
+        self.assertLessEqual(pct, 100)
 
-    def test_pct_is_int(self):
-        result = self._run_with_dplus(1.80)
-        self.assertIsInstance(result["battery_pct"], int)
+    def test_ina260_fields_are_none(self):
+        result = self._status(1.80)
+        self.assertIsNone(result["current_ma"])
+        self.assertIsNone(result["mah_remaining"])
 
+
+# ---------------------------------------------------------------------------
+# INA260 coulomb-counting path
+# ---------------------------------------------------------------------------
+
+class TestCoulombCounting(unittest.TestCase):
+
+    def test_discharge_reduces_remaining(self):
+        state = {"mah_remaining": 13500.0, "last_updated_utc": None}
+        remaining = bm._update_coulomb_state(state, current_ma=1000.0, elapsed_s=3600.0)
+        self.assertAlmostEqual(remaining, 12500.0, places=1)
+
+    def test_discharge_clamps_to_zero(self):
+        state = {"mah_remaining": 10.0, "last_updated_utc": None}
+        remaining = bm._update_coulomb_state(state, current_ma=5000.0, elapsed_s=3600.0)
+        self.assertEqual(remaining, 0.0)
+
+    def test_zero_elapsed_no_change(self):
+        state = {"mah_remaining": 8000.0, "last_updated_utc": None}
+        remaining = bm._update_coulomb_state(state, current_ma=1000.0, elapsed_s=0.0)
+        self.assertAlmostEqual(remaining, 8000.0)
+
+    def test_elapsed_seconds_valid_timestamp(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        elapsed = bm._elapsed_seconds_since(past)
+        self.assertGreater(elapsed, 3500)
+        self.assertLess(elapsed, 3700)
+
+    def test_elapsed_seconds_none_returns_zero(self):
+        self.assertEqual(bm._elapsed_seconds_since(None), 0.0)
+
+    def test_elapsed_seconds_bad_string_returns_zero(self):
+        self.assertEqual(bm._elapsed_seconds_since("not-a-date"), 0.0)
+
+
+class TestStateFile(unittest.TestCase):
+
+    def test_save_and_load_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = os.path.join(tmpdir, "battery_state.json")
+            with patch.object(bm, "STATE_FILE", state_file):
+                state_in = {"mah_remaining": 9876.5, "calibrated": True,
+                            "last_updated_utc": "2026-01-01T00:00:00+00:00"}
+                bm._save_state(state_in)
+                state_out = bm._load_state()
+            self.assertAlmostEqual(state_out["mah_remaining"], 9876.5)
+
+    def test_missing_file_returns_full_capacity(self):
+        with patch.object(bm, "STATE_FILE", "/nonexistent/path/battery_state.json"):
+            state = bm._load_state()
+        self.assertAlmostEqual(state["mah_remaining"], bm.VOLTAIC_V50_MAH)
+
+    def test_missing_mah_key_defaults_to_full(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = os.path.join(tmpdir, "battery_state.json")
+            with open(state_file, "w") as f:
+                json.dump({"calibrated": False}, f)
+            with patch.object(bm, "STATE_FILE", state_file):
+                state = bm._load_state()
+            self.assertAlmostEqual(state["mah_remaining"], bm.VOLTAIC_V50_MAH)
+
+
+class TestINA260Path(unittest.TestCase):
+
+    def _status_with_ina(self, mah_remaining=6750.0, current_ma=500.0):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = os.path.join(tmpdir, "battery_state.json")
+            seed = {"mah_remaining": mah_remaining, "calibrated": True,
+                    "last_updated_utc": None}
+            with open(state_file, "w") as f:
+                json.dump(seed, f)
+            with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+                with patch.object(bm, "_read_ina260", return_value=(5.1, current_ma, 2550.0)):
+                    with patch.object(bm, "STATE_FILE", state_file):
+                        return bm.get_battery_status()
+
+    def test_source_tag(self):
+        self.assertEqual(self._status_with_ina()["battery_source"], "ina260")
+
+    def test_pct_at_half_capacity(self):
+        result = self._status_with_ina(mah_remaining=bm.VOLTAIC_V50_MAH / 2)
+        self.assertEqual(result["battery_pct"], 50)
+
+    def test_ads1115_fields_are_none(self):
+        result = self._status_with_ina()
+        self.assertIsNone(result["d_plus_v"])
+        self.assertIsNone(result["cell_voltage_v"])
+
+    def test_current_ma_returned(self):
+        result = self._status_with_ina(current_ma=750.0)
+        self.assertAlmostEqual(result["current_ma"], 750.0, places=1)
+
+
+# ---------------------------------------------------------------------------
+# Fallback chain
+# ---------------------------------------------------------------------------
+
+class TestFallbackChain(unittest.TestCase):
+
+    def test_ads1115_takes_priority_over_ina260(self):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=1.80):
+            with patch.object(bm, "_read_ina260", return_value=(5.1, 500.0, 2550.0)):
+                result = bm.get_battery_status()
+        self.assertEqual(result["battery_source"], "ads1115_dplus")
+
+    def test_ina260_used_when_ads1115_absent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = os.path.join(tmpdir, "s.json")
+            with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+                with patch.object(bm, "_read_ina260", return_value=(5.1, 500.0, 2550.0)):
+                    with patch.object(bm, "STATE_FILE", state_file):
+                        result = bm.get_battery_status()
+        self.assertEqual(result["battery_source"], "ina260")
+
+    def test_unavailable_when_both_absent(self):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+            with patch.object(bm, "_read_ina260", return_value=None):
+                with patch.object(bm, "_log_wittypi_vin_diagnostic"):
+                    result = bm.get_battery_status()
+        self.assertIsNone(result["battery_pct"])
+        self.assertEqual(result["battery_source"], "unavailable")
+
+    def test_unavailable_does_not_raise(self):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+            with patch.object(bm, "_read_ina260", return_value=None):
+                with patch.object(bm, "_log_wittypi_vin_diagnostic"):
+                    try:
+                        bm.get_battery_status()
+                    except Exception as e:
+                        self.fail(f"get_battery_status raised unexpectedly: {e}")
+
+
+# ---------------------------------------------------------------------------
+# LoRa packet encoding
+# ---------------------------------------------------------------------------
 
 class TestLoRaPacketEncoding(unittest.TestCase):
-    """battery_percent=None must be skipped in compressed_encoding."""
 
     def setUp(self):
-        serial_mock = MagicMock()
-        sys.modules.setdefault("serial", serial_mock)
+        sys.modules.setdefault("serial", MagicMock())
 
-    def test_none_battery_excluded_from_packet(self):
+    def test_none_battery_excluded(self):
         import importlib
         import tools.lora_transmit as lt
         importlib.reload(lt)
-        data = {"timestamp": 1000000, "temperature_celsius": 20.0, "battery_percent": None}
-        packet = lt.compressed_encoding(data)
+        packet = lt.compressed_encoding({"timestamp": 1000000, "battery_percent": None})
         self.assertNotIn("0201", packet.hex())
 
-    def test_valid_battery_included_in_packet(self):
+    def test_valid_battery_included(self):
         import importlib
         import tools.lora_transmit as lt
         importlib.reload(lt)
-        data = {"timestamp": 1000000, "battery_percent": 75}
-        packet = lt.compressed_encoding(data)
+        packet = lt.compressed_encoding({"timestamp": 1000000, "battery_percent": 75})
         self.assertIn("0201", packet.hex())
 
-    def test_zero_battery_included_in_packet(self):
+    def test_zero_battery_included(self):
         import importlib
         import tools.lora_transmit as lt
         importlib.reload(lt)
-        data = {"timestamp": 1000000, "battery_percent": 0}
-        packet = lt.compressed_encoding(data)
+        packet = lt.compressed_encoding({"timestamp": 1000000, "battery_percent": 0})
         self.assertIn("0201", packet.hex())
 
 

--- a/tests/test_battery_manager.py
+++ b/tests/test_battery_manager.py
@@ -115,6 +115,15 @@ class TestCoulombCounting(unittest.TestCase):
     def test_elapsed_seconds_bad_string_returns_zero(self):
         self.assertEqual(bm._elapsed_seconds_since("not-a-date"), 0.0)
 
+    def test_elapsed_seconds_naive_datetime_does_not_raise(self):
+        # Naive ISO timestamp (no timezone) must not raise TypeError
+        naive_ts = "2026-01-01T00:00:00"
+        try:
+            elapsed = bm._elapsed_seconds_since(naive_ts)
+            self.assertGreater(elapsed, 0)
+        except TypeError:
+            self.fail("_elapsed_seconds_since raised TypeError on naive timestamp")
+
 
 class TestStateFile(unittest.TestCase):
 

--- a/tests/test_battery_manager.py
+++ b/tests/test_battery_manager.py
@@ -1,130 +1,117 @@
-"""Tests for tools/battery_manager.py"""
+"""Tests for tools/battery_manager.py (ADS1115 + D+ pin SOC estimation)."""
 
-import json
 import os
-import tempfile
+import sys
 import unittest
-from unittest.mock import patch, MagicMock
-from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import tools.battery_manager as bm
 
 
-class TestCoulombCounting(unittest.TestCase):
+class TestCellVoltageToPct(unittest.TestCase):
 
-    def setUp(self):
-        import sys
-        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-        import tools.battery_manager as bm
-        self.bm = bm
+    def test_full_cell_voltage(self):
+        self.assertEqual(bm._cell_voltage_to_pct(4.2), 100)
 
-    def test_full_capacity_on_fresh_state(self):
-        state = self.bm._load_state.__func__ if hasattr(self.bm._load_state, "__func__") else None
-        # _load_state with missing file returns full capacity
-        with patch("builtins.open", side_effect=FileNotFoundError):
-            state = self.bm._load_state()
-        self.assertAlmostEqual(state["mah_remaining"], self.bm.VOLTAIC_V50_MAH)
-        self.assertFalse(state["calibrated"])
+    def test_empty_cell_voltage(self):
+        self.assertEqual(bm._cell_voltage_to_pct(3.0), 0)
 
-    def test_discharge_reduces_remaining(self):
-        state = {"mah_remaining": 13500.0, "last_updated_utc": None, "calibrated": True}
-        # 1000 mA draw for 1 hour = 1000 mAh consumed
-        remaining = self.bm._update_coulomb_state(state, current_ma=1000.0, elapsed_s=3600.0)
-        self.assertAlmostEqual(remaining, 12500.0, places=1)
+    def test_midpoint(self):
+        mid_v = (bm.CELL_V_MIN + bm.CELL_V_MAX) / 2   # 3.6V → 50%
+        self.assertEqual(bm._cell_voltage_to_pct(mid_v), 50)
 
-    def test_discharge_clamps_to_zero(self):
-        state = {"mah_remaining": 10.0, "last_updated_utc": None, "calibrated": True}
-        remaining = self.bm._update_coulomb_state(state, current_ma=5000.0, elapsed_s=3600.0)
-        self.assertEqual(remaining, 0.0)
+    def test_above_max_clamps_to_100(self):
+        self.assertEqual(bm._cell_voltage_to_pct(5.0), 100)
 
-    def test_zero_elapsed_no_change(self):
-        state = {"mah_remaining": 8000.0, "last_updated_utc": None, "calibrated": True}
-        remaining = self.bm._update_coulomb_state(state, current_ma=1000.0, elapsed_s=0.0)
-        self.assertAlmostEqual(remaining, 8000.0)
+    def test_below_min_clamps_to_zero(self):
+        self.assertEqual(bm._cell_voltage_to_pct(1.0), 0)
 
-    def test_soc_percent_from_mah(self):
-        mah = self.bm.VOLTAIC_V50_MAH * 0.75
-        pct = max(0, min(100, int(mah / self.bm.VOLTAIC_V50_MAH * 100)))
-        self.assertEqual(pct, 75)
+    def test_empirical_observed_full(self):
+        # Voltaic blog reports ~1.85V D+ at observed full → cell ~3.7V → ~58%
+        d_plus = 1.85
+        cell_v = d_plus * 2.0
+        pct = bm._cell_voltage_to_pct(cell_v)
+        self.assertGreater(pct, 50)
+        self.assertLess(pct, 75)
 
-    def test_elapsed_seconds_valid_timestamp(self):
-        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-        elapsed = self.bm._elapsed_seconds_since(past)
-        self.assertGreater(elapsed, 3500)
-        self.assertLess(elapsed, 3700)
+    def test_empirical_observed_empty(self):
+        # Voltaic blog reports ~1.54V D+ at observed empty → cell ~3.08V → ~7%
+        d_plus = 1.54
+        cell_v = d_plus * 2.0
+        pct = bm._cell_voltage_to_pct(cell_v)
+        self.assertGreaterEqual(pct, 0)
+        self.assertLess(pct, 15)
 
-    def test_elapsed_seconds_none_returns_zero(self):
-        self.assertEqual(self.bm._elapsed_seconds_since(None), 0.0)
-
-    def test_elapsed_seconds_bad_string_returns_zero(self):
-        self.assertEqual(self.bm._elapsed_seconds_since("not-a-date"), 0.0)
-
-
-class TestStateFile(unittest.TestCase):
-
-    def setUp(self):
-        import sys
-        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-        import tools.battery_manager as bm
-        self.bm = bm
-
-    def test_save_and_load_roundtrip(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            test_state_file = os.path.join(tmpdir, "battery_state.json")
-            with patch.object(self.bm, "STATE_FILE", test_state_file):
-                state_in = {"mah_remaining": 9876.5, "calibrated": True, "last_updated_utc": "2026-01-01T00:00:00+00:00"}
-                self.bm._save_state(state_in)
-                state_out = self.bm._load_state()
-            self.assertAlmostEqual(state_out["mah_remaining"], 9876.5)
-            self.assertTrue(state_out["calibrated"])
-
-    def test_load_missing_file_returns_defaults(self):
-        with patch.object(self.bm, "STATE_FILE", "/nonexistent/path/battery_state.json"):
-            state = self.bm._load_state()
-        self.assertAlmostEqual(state["mah_remaining"], self.bm.VOLTAIC_V50_MAH)
+    def test_returns_int(self):
+        result = bm._cell_voltage_to_pct(3.6)
+        self.assertIsInstance(result, int)
 
 
 class TestGetBatteryStatusFallback(unittest.TestCase):
-    """When INA260 hardware is absent, get_battery_status() must return unavailable."""
-
-    def setUp(self):
-        import sys
-        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-        import tools.battery_manager as bm
-        self.bm = bm
+    """When ADS1115 is absent, get_battery_status() returns unavailable."""
 
     def test_no_hardware_returns_none_pct(self):
-        with patch.object(self.bm, "_read_ina260", return_value=None):
-            with patch.object(self.bm, "_log_wittypi_vin_diagnostic"):
-                result = self.bm.get_battery_status()
+        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+            with patch.object(bm, "_log_wittypi_vin_diagnostic"):
+                result = bm.get_battery_status()
         self.assertIsNone(result["battery_pct"])
         self.assertEqual(result["battery_source"], "unavailable")
+        self.assertIsNone(result["cell_voltage_v"])
+        self.assertIsNone(result["d_plus_v"])
 
-    def test_ina260_present_returns_pct(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            test_state_file = os.path.join(tmpdir, "battery_state.json")
-            # Seed state at 50%
-            seed = {"mah_remaining": self.bm.VOLTAIC_V50_MAH * 0.5,
-                    "calibrated": True,
-                    "last_updated_utc": None}
-            with open(test_state_file, "w") as f:
-                json.dump(seed, f)
+    def test_no_hardware_does_not_raise(self):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=None):
+            with patch.object(bm, "_log_wittypi_vin_diagnostic"):
+                try:
+                    bm.get_battery_status()
+                except Exception as e:
+                    self.fail(f"get_battery_status raised unexpectedly: {e}")
 
-            with patch.object(self.bm, "_read_ina260", return_value=(5.1, 500.0, 2550.0)):
-                with patch.object(self.bm, "STATE_FILE", test_state_file):
-                    result = self.bm.get_battery_status()
 
-        self.assertEqual(result["battery_source"], "ina260")
-        self.assertIsNotNone(result["battery_pct"])
+class TestGetBatteryStatusWithHardware(unittest.TestCase):
+    """When ADS1115 reads a valid D+ voltage, SOC is computed correctly."""
+
+    def _run_with_dplus(self, d_plus_v):
+        with patch.object(bm, "_read_ads1115_dplus", return_value=d_plus_v):
+            return bm.get_battery_status()
+
+    def test_source_tag(self):
+        result = self._run_with_dplus(1.85)
+        self.assertEqual(result["battery_source"], "ads1115_dplus")
+
+    def test_d_plus_v_returned(self):
+        result = self._run_with_dplus(1.75)
+        self.assertAlmostEqual(result["d_plus_v"], 1.75, places=3)
+
+    def test_cell_voltage_is_double_dplus(self):
+        result = self._run_with_dplus(1.85)
+        self.assertAlmostEqual(result["cell_voltage_v"], 3.70, places=2)
+
+    def test_full_charge(self):
+        # D+ = 2.1V → cell = 4.2V → 100%
+        result = self._run_with_dplus(2.1)
+        self.assertEqual(result["battery_pct"], 100)
+
+    def test_empty(self):
+        # D+ = 1.5V → cell = 3.0V → 0%
+        result = self._run_with_dplus(1.5)
+        self.assertEqual(result["battery_pct"], 0)
+
+    def test_pct_in_range(self):
+        result = self._run_with_dplus(1.75)
         self.assertGreaterEqual(result["battery_pct"], 0)
         self.assertLessEqual(result["battery_pct"], 100)
 
+    def test_pct_is_int(self):
+        result = self._run_with_dplus(1.80)
+        self.assertIsInstance(result["battery_pct"], int)
+
 
 class TestLoRaPacketEncoding(unittest.TestCase):
-    """Verify battery_percent=None is skipped in lora_transmit.compressed_encoding."""
+    """battery_percent=None must be skipped in compressed_encoding."""
 
     def setUp(self):
-        import sys
-        sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-        # lora_transmit.py imports serial at module level; stub it out
         serial_mock = MagicMock()
         sys.modules.setdefault("serial", serial_mock)
 
@@ -134,7 +121,6 @@ class TestLoRaPacketEncoding(unittest.TestCase):
         importlib.reload(lt)
         data = {"timestamp": 1000000, "temperature_celsius": 20.0, "battery_percent": None}
         packet = lt.compressed_encoding(data)
-        # Channel 0x02 0x01 must not appear
         self.assertNotIn("0201", packet.hex())
 
     def test_valid_battery_included_in_packet(self):
@@ -142,6 +128,14 @@ class TestLoRaPacketEncoding(unittest.TestCase):
         import tools.lora_transmit as lt
         importlib.reload(lt)
         data = {"timestamp": 1000000, "battery_percent": 75}
+        packet = lt.compressed_encoding(data)
+        self.assertIn("0201", packet.hex())
+
+    def test_zero_battery_included_in_packet(self):
+        import importlib
+        import tools.lora_transmit as lt
+        importlib.reload(lt)
+        data = {"timestamp": 1000000, "battery_percent": 0}
         packet = lt.compressed_encoding(data)
         self.assertIn("0201", packet.hex())
 

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -242,22 +242,33 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
     except Exception as e:
         print(f"⚠️ Failed to get GPS data: {e}")
     
-    # Get WittyPi voltage measurements for battery status
+    # Get WittyPi temperature and voltage diagnostics
     try:
         from tools.wittypi_control import get_wittypi_status
         wittypi_data = get_wittypi_status()
         if wittypi_data.get('status') == 'wittypi_data_retrieved':
             data.update({
                 'wittypi_temperature': wittypi_data.get('temperature', 0.0),
-                'wittypi_battery_voltage': wittypi_data.get('battery_voltage', 0.0),
                 'wittypi_internal_voltage': wittypi_data.get('internal_voltage', 0.0)
             })
-            print(f"🔋 WittyPi data added: temp={wittypi_data.get('temperature', 0.0)}°C, battery={wittypi_data.get('battery_voltage', 0.0)}V, internal={wittypi_data.get('internal_voltage', 0.0)}V")
+            print(f"WittyPi data: temp={wittypi_data.get('temperature', 0.0)}°C, internal={wittypi_data.get('internal_voltage', 0.0)}V")
         else:
             print(f"⚠️ WittyPi data unavailable: {wittypi_data.get('status', 'unknown')}")
     except Exception as e:
         print(f"⚠️ Failed to get WittyPi data: {e}")
-    
+
+    # Get battery state-of-charge from INA260 coulomb counter
+    try:
+        from tools.battery_manager import get_battery_status
+        batt_status = get_battery_status()
+        data['battery_percent'] = batt_status['battery_pct']
+        data['battery_source'] = batt_status['battery_source']
+        print(f"Battery: {batt_status['battery_pct']}% ({batt_status['battery_source']})")
+    except Exception as e:
+        print(f"⚠️ Failed to get battery status: {e}")
+        data['battery_pct'] = None
+        data['battery_source'] = 'unavailable'
+
     # Add runtime parameters to sensor data
     emergency_mode = get_parameter('emergency_mode', False)
     area_threshold = get_parameter('area_threshold', 10)
@@ -768,22 +779,33 @@ def lora_token(bitmap):
     except Exception as e:
         print(f"⚠️ Failed to get GPS data: {e}")
     
-    # Get WittyPi voltage measurements for battery status
+    # Get WittyPi temperature and voltage diagnostics
     try:
         from tools.wittypi_control import get_wittypi_status
         wittypi_data = get_wittypi_status()
         if wittypi_data.get('status') == 'wittypi_data_retrieved':
             data.update({
                 'wittypi_temperature': wittypi_data.get('temperature', 0.0),
-                'wittypi_battery_voltage': wittypi_data.get('battery_voltage', 0.0),
                 'wittypi_internal_voltage': wittypi_data.get('internal_voltage', 0.0)
             })
-            print(f"🔋 WittyPi data added: temp={wittypi_data.get('temperature', 0.0)}°C, battery={wittypi_data.get('battery_voltage', 0.0)}V, internal={wittypi_data.get('internal_voltage', 0.0)}V")
+            print(f"WittyPi data: temp={wittypi_data.get('temperature', 0.0)}°C, internal={wittypi_data.get('internal_voltage', 0.0)}V")
         else:
             print(f"⚠️ WittyPi data unavailable: {wittypi_data.get('status', 'unknown')}")
     except Exception as e:
         print(f"⚠️ Failed to get WittyPi data: {e}")
-    
+
+    # Get battery state-of-charge from INA260 coulomb counter
+    try:
+        from tools.battery_manager import get_battery_status
+        batt_status = get_battery_status()
+        data['battery_percent'] = batt_status['battery_pct']
+        data['battery_source'] = batt_status['battery_source']
+        print(f"Battery: {batt_status['battery_pct']}% ({batt_status['battery_source']})")
+    except Exception as e:
+        print(f"⚠️ Failed to get battery status: {e}")
+        data['battery_pct'] = None
+        data['battery_source'] = 'unavailable'
+
     # Add runtime parameters to sensor data
     emergency_mode = get_parameter('emergency_mode', False)
     area_threshold = get_parameter('area_threshold', 10)
@@ -1550,12 +1572,15 @@ def ip_uplink_transmit(bitmap, _sensor_tracker):
             print(f"⚠️ IP uplink: GPS unavailable: {e}")
 
         try:
-            from tools.wittypi_control import get_wittypi_status
-            wittypi_data = get_wittypi_status()
-            if wittypi_data.get('status') == 'wittypi_data_retrieved':
-                data['wittypi_battery_voltage'] = wittypi_data.get('battery_voltage', 0.0)
+            from tools.battery_manager import get_battery_status
+            batt_status = get_battery_status()
+            data['battery_percent'] = batt_status['battery_pct']
+            data['battery_source'] = batt_status['battery_source']
+            data['battery_input_voltage_v'] = batt_status['input_voltage_v']
         except Exception as e:
-            print(f"⚠️ IP uplink: WittyPi unavailable: {e}")
+            print(f"⚠️ IP uplink: battery manager unavailable: {e}")
+            data['battery_percent'] = None
+            data['battery_source'] = 'unavailable'
 
         data['area_threshold']                    = get_parameter('area_threshold', 10)
         data['stage_threshold']                   = get_parameter('stage_threshold', 50)
@@ -1570,10 +1595,9 @@ def ip_uplink_transmit(bitmap, _sensor_tracker):
         # 00 01 — device timestamp (8-byte uint64)
         channels.append({"code": "00 01", "payload_hex": struct.pack(">Q", ts_now).hex()})
 
-        # 02 01 — battery percent derived from WittyPi voltage (LiPo: 3.0V=0%, 4.2V=100%)
-        batt_v = data.get('wittypi_battery_voltage', 0.0)
-        if batt_v and batt_v > 0:
-            batt_pct = max(0, min(100, int((batt_v - 3.0) / 1.2 * 100)))
+        # 02 01 — battery percent from INA260 coulomb counter; omitted when unavailable
+        batt_pct = data.get('battery_percent')
+        if batt_pct is not None:
             channels.append({"code": "02 01", "payload_hex": struct.pack(">I", batt_pct).hex()})
 
         # 04 01 — GPS block (lat int32 microdeg, lon int32 microdeg)

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -266,7 +266,7 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
         print(f"Battery: {batt_status['battery_pct']}% ({batt_status['battery_source']})")
     except Exception as e:
         print(f"⚠️ Failed to get battery status: {e}")
-        data['battery_pct'] = None
+        data['battery_percent'] = None
         data['battery_source'] = 'unavailable'
 
     # Add runtime parameters to sensor data
@@ -522,13 +522,14 @@ def manual_wittypi_control(action, **kwargs):
             }
             
         elif action == 'get_status':
-            temperature, battery_voltage, internal_voltage = get_data()
+            temperature, battery_voltage, internal_voltage, internal_current = get_data()
             return {
                 'status': 'data_retrieved',
                 'action': 'get_status',
                 'temperature': temperature,
                 'battery_voltage': battery_voltage,
-                'internal_voltage': internal_voltage
+                'internal_voltage': internal_voltage,
+                'internal_current': internal_current
             }
             
         elif action == 'sync_time':
@@ -803,7 +804,7 @@ def lora_token(bitmap):
         print(f"Battery: {batt_status['battery_pct']}% ({batt_status['battery_source']})")
     except Exception as e:
         print(f"⚠️ Failed to get battery status: {e}")
-        data['battery_pct'] = None
+        data['battery_percent'] = None
         data['battery_source'] = 'unavailable'
 
     # Add runtime parameters to sensor data
@@ -1576,7 +1577,6 @@ def ip_uplink_transmit(bitmap, _sensor_tracker):
             batt_status = get_battery_status()
             data['battery_percent'] = batt_status['battery_pct']
             data['battery_source'] = batt_status['battery_source']
-            data['battery_input_voltage_v'] = batt_status['input_voltage_v']
         except Exception as e:
             print(f"⚠️ IP uplink: battery manager unavailable: {e}")
             data['battery_percent'] = None

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -243,6 +243,7 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
         print(f"⚠️ Failed to get GPS data: {e}")
     
     # Get WittyPi temperature and voltage diagnostics
+    wittypi_data = None
     try:
         from tools.wittypi_control import get_wittypi_status
         wittypi_data = get_wittypi_status()
@@ -260,7 +261,7 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
     # Get battery state-of-charge from battery_manager (path varies by hardware)
     try:
         from tools.battery_manager import get_battery_status
-        batt_status = get_battery_status()
+        batt_status = get_battery_status(wittypi_data=wittypi_data)
         data['battery_percent'] = batt_status['battery_pct']
         data['battery_source'] = batt_status['battery_source']  # device-side diagnostic; not transmitted
         pct = batt_status['battery_pct']
@@ -783,6 +784,7 @@ def lora_token(bitmap):
         print(f"⚠️ Failed to get GPS data: {e}")
     
     # Get WittyPi temperature and voltage diagnostics
+    wittypi_data = None
     try:
         from tools.wittypi_control import get_wittypi_status
         wittypi_data = get_wittypi_status()
@@ -800,7 +802,7 @@ def lora_token(bitmap):
     # Get battery state-of-charge from battery_manager (path varies by hardware)
     try:
         from tools.battery_manager import get_battery_status
-        batt_status = get_battery_status()
+        batt_status = get_battery_status(wittypi_data=wittypi_data)
         data['battery_percent'] = batt_status['battery_pct']
         data['battery_source'] = batt_status['battery_source']  # device-side diagnostic; not transmitted
         pct = batt_status['battery_pct']

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -1527,7 +1527,8 @@ def ip_uplink_transmit(bitmap, _sensor_tracker):
     """Send a subset of sensor readings and the flood bitmap to the FastAPI server over IP.
 
     Encodes the following channels as channel-coded hex blocks and POSTs to
-    /ip/uplink: device_ts, battery_pct (from WittyPi), GPS lat/lon, temperature,
+    /ip/uplink: device_ts, battery_pct (from battery_manager; source varies by
+    available hardware — ADS1115 D+, INA260, or WittyPi output), GPS lat/lon, temperature,
     humidity, flood_detect (inferred from bitmap), flood_bitmap, and the five
     status-report parameters.  IMU data is not included.
 

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -257,13 +257,15 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
     except Exception as e:
         print(f"⚠️ Failed to get WittyPi data: {e}")
 
-    # Get battery state-of-charge from INA260 coulomb counter
+    # Get battery state-of-charge from battery_manager (path varies by hardware)
     try:
         from tools.battery_manager import get_battery_status
         batt_status = get_battery_status()
         data['battery_percent'] = batt_status['battery_pct']
-        data['battery_source'] = batt_status['battery_source']
-        print(f"Battery: {batt_status['battery_pct']}% ({batt_status['battery_source']})")
+        data['battery_source'] = batt_status['battery_source']  # device-side diagnostic; not transmitted
+        pct = batt_status['battery_pct']
+        src = batt_status['battery_source']
+        print(f"Battery: {pct}% ({src})" if pct is not None else f"Battery: unavailable ({src})")
     except Exception as e:
         print(f"⚠️ Failed to get battery status: {e}")
         data['battery_percent'] = None
@@ -795,13 +797,15 @@ def lora_token(bitmap):
     except Exception as e:
         print(f"⚠️ Failed to get WittyPi data: {e}")
 
-    # Get battery state-of-charge from INA260 coulomb counter
+    # Get battery state-of-charge from battery_manager (path varies by hardware)
     try:
         from tools.battery_manager import get_battery_status
         batt_status = get_battery_status()
         data['battery_percent'] = batt_status['battery_pct']
-        data['battery_source'] = batt_status['battery_source']
-        print(f"Battery: {batt_status['battery_pct']}% ({batt_status['battery_source']})")
+        data['battery_source'] = batt_status['battery_source']  # device-side diagnostic; not transmitted
+        pct = batt_status['battery_pct']
+        src = batt_status['battery_source']
+        print(f"Battery: {pct}% ({src})" if pct is not None else f"Battery: unavailable ({src})")
     except Exception as e:
         print(f"⚠️ Failed to get battery status: {e}")
         data['battery_percent'] = None
@@ -1595,7 +1599,7 @@ def ip_uplink_transmit(bitmap, _sensor_tracker):
         # 00 01 — device timestamp (8-byte uint64)
         channels.append({"code": "00 01", "payload_hex": struct.pack(">Q", ts_now).hex()})
 
-        # 02 01 — battery percent from INA260 coulomb counter; omitted when unavailable
+        # 02 01 — battery percent from battery_manager (source varies by hardware); omitted when unavailable
         batt_pct = data.get('battery_percent')
         if batt_pct is not None:
             channels.append({"code": "02 01", "payload_hex": struct.pack(">I", batt_pct).hex()})

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -50,7 +50,9 @@ CELL_V_MAX = 4.2   # cell voltage at 100% SOC
 # ── INA260 constants ───────────────────────────────────────────────────────
 INA260_I2C_ADDRESS = 0x40
 VOLTAIC_V50_MAH = 13500.0
-STATE_FILE = "/var/lib/watercam/battery_state.json"
+# Stored in the project root so it stays within the home directory on all deployments.
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STATE_FILE = os.path.join(_PROJECT_ROOT, "battery_state.json")
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +223,6 @@ def _load_state() -> dict:
 
 def _save_state(state: dict) -> None:
     try:
-        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
         with open(STATE_FILE, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2)
     except Exception as e:

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -1,0 +1,177 @@
+"""
+Battery state-of-charge estimation for the UFONet HazMapper WaterCam unit.
+
+Hardware: Voltaic V50 battery pack (50 Wh, ~13 500 mAh at 3.7 V nominal).
+The V50 outputs regulated 5 V USB — raw cell voltage is not exposed.
+SOC is estimated via coulomb counting using an Adafruit INA260 power monitor
+(Product #4226) placed in-line on the power feed from the Voltaic V50 to the
+WittyPi 4 input.
+
+Without an INA260 the module returns battery_source="unavailable" and
+battery_pct=None so callers can omit the battery channel from transmissions
+rather than sending a wrong value.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+STATE_FILE = "/var/lib/watercam/battery_state.json"
+VOLTAIC_V50_MAH = 13500.0
+INA260_I2C_ADDRESS = 0x40
+
+
+def get_battery_status() -> dict:
+    """Return current battery state-of-charge and supporting diagnostics.
+
+    Returns a dict with keys:
+        battery_pct      int | None   — 0-100, or None if unavailable
+        battery_source   str          — "ina260" or "unavailable"
+        input_voltage_v  float | None — raw INA260 bus voltage (V)
+        current_ma       float | None — instantaneous current draw (mA)
+        mah_remaining    float | None — coulomb-counted remaining charge
+    """
+    ina_reading = _read_ina260()
+    if ina_reading is None:
+        _log_wittypi_vin_diagnostic()
+        return {
+            "battery_pct": None,
+            "battery_source": "unavailable",
+            "input_voltage_v": None,
+            "current_ma": None,
+            "mah_remaining": None,
+        }
+
+    voltage_v, current_ma, _ = ina_reading
+    state = _load_state()
+    elapsed_s = _elapsed_seconds_since(state.get("last_updated_utc"))
+    mah_remaining = _update_coulomb_state(state, current_ma, elapsed_s)
+    _save_state(state)
+
+    battery_pct = max(0, min(100, int(mah_remaining / VOLTAIC_V50_MAH * 100)))
+    logging.info(
+        "Battery: %.1f mAh remaining (%.0f%%), %.3f V, %.1f mA",
+        mah_remaining, battery_pct, voltage_v, current_ma,
+    )
+    return {
+        "battery_pct": battery_pct,
+        "battery_source": "ina260",
+        "input_voltage_v": voltage_v,
+        "current_ma": current_ma,
+        "mah_remaining": mah_remaining,
+    }
+
+
+def calibrate_full_charge() -> None:
+    """Reset coulomb counter to 100% (call when pack is known to be fully charged)."""
+    state = _load_state()
+    state["mah_remaining"] = VOLTAIC_V50_MAH
+    state["calibrated"] = True
+    state["last_updated_utc"] = datetime.now(timezone.utc).isoformat()
+    _save_state(state)
+    logging.info("Battery coulomb counter reset to full (%.0f mAh)", VOLTAIC_V50_MAH)
+
+
+# ---------------------------------------------------------------------------
+# INA260 hardware interface
+# ---------------------------------------------------------------------------
+
+def _read_ina260() -> Optional[tuple[float, float, float]]:
+    """Read voltage (V), current (mA), power (mW) from INA260 over I2C.
+
+    Returns None if the INA260 is not detected (hardware not installed).
+    """
+    try:
+        import board  # type: ignore
+        import busio  # type: ignore
+        import adafruit_ina260  # type: ignore
+
+        i2c = busio.I2C(board.SCL, board.SDA)
+        ina = adafruit_ina260.INA260(i2c, address=INA260_I2C_ADDRESS)
+        voltage_v = ina.voltage
+        current_ma = ina.current
+        power_mw = ina.power
+        return float(voltage_v), float(current_ma), float(power_mw)
+    except Exception as e:
+        logging.debug("INA260 not available: %s", e)
+        return None
+
+
+def _log_wittypi_vin_diagnostic() -> None:
+    """Log the raw WittyPi VIN reading for diagnostic purposes only.
+
+    This value is ~5 V (regulated) when the Voltaic V50 is connected via
+    USB-C and does NOT reflect state of charge. It is logged only so that
+    unexpected VIN values (e.g. <4.5 V indicating a cable fault) appear in
+    system logs.
+    """
+    try:
+        from tools.wittypi_control import get_wittypi_status
+        data = get_wittypi_status()
+        vin = data.get("battery_voltage", None)
+        if vin is not None:
+            logging.debug("WittyPi VIN (diagnostic only, not SOC): %.3f V", vin)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Coulomb counting
+# ---------------------------------------------------------------------------
+
+def _update_coulomb_state(state: dict, current_ma: float, elapsed_s: float) -> float:
+    """Subtract consumed mAh from state and return updated mah_remaining."""
+    if elapsed_s <= 0:
+        return state.get("mah_remaining", VOLTAIC_V50_MAH)
+
+    elapsed_h = elapsed_s / 3600.0
+    # current_ma is draw from battery; positive = discharging
+    mah_consumed = current_ma * elapsed_h
+    mah_remaining = state.get("mah_remaining", VOLTAIC_V50_MAH) - mah_consumed
+    mah_remaining = max(0.0, min(VOLTAIC_V50_MAH, mah_remaining))
+
+    state["mah_remaining"] = mah_remaining
+    state["last_updated_utc"] = datetime.now(timezone.utc).isoformat()
+    return mah_remaining
+
+
+def _elapsed_seconds_since(iso_timestamp: Optional[str]) -> float:
+    """Return seconds elapsed since iso_timestamp, or 0 if unknown/invalid."""
+    if not iso_timestamp:
+        return 0.0
+    try:
+        last = datetime.fromisoformat(iso_timestamp)
+        now = datetime.now(timezone.utc)
+        delta = (now - last).total_seconds()
+        return max(0.0, delta)
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+def _load_state() -> dict:
+    try:
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            state = json.load(f)
+        if "mah_remaining" not in state:
+            state["mah_remaining"] = VOLTAIC_V50_MAH
+        return state
+    except FileNotFoundError:
+        return {"mah_remaining": VOLTAIC_V50_MAH, "calibrated": False, "last_updated_utc": None}
+    except Exception as e:
+        logging.warning("Could not load battery state: %s — starting fresh", e)
+        return {"mah_remaining": VOLTAIC_V50_MAH, "calibrated": False, "last_updated_utc": None}
+
+
+def _save_state(state: dict) -> None:
+    try:
+        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+        with open(STATE_FILE, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+    except Exception as e:
+        logging.warning("Could not save battery state: %s", e)

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -3,24 +3,33 @@ Battery state-of-charge estimation for the UFONet HazMapper WaterCam unit.
 
 Hardware: Voltaic V50 battery pack (50 Wh, ~13 500 mAh at 3.7 V nominal).
 
-Two measurement paths are supported, tried in priority order:
+Three measurement paths are supported, tried in priority order:
 
-  1. ADS1115 + D+ pin (preferred)
+  1. ADS1115 + D+ pin (preferred — most accurate)
      The Voltaic V50 outputs ~½ cell voltage on its USB-C D+ pin (1.5–2.1 V).
      An Adafruit ADS1115 ADC (Product #1085) reads this directly.
      No drift, no state file, fresh reading every boot.
      Ref: https://blog.voltaicsystems.com/reading-charge-level-of-voltaic-usb-battery-packs/
      BOM: ADS1115 #1085 + USB-C breakout #4090 + STEMMA QT cable.
 
-  2. INA260 coulomb counting (fallback)
+  2. INA260 coulomb counting (fallback — accurate, drifts over time)
      An Adafruit INA260 power monitor (Product #4226) placed in-line on the
      power feed measures current draw. Accumulated mAh is persisted to a state
      file so the counter survives WittyPi-scheduled reboots.
      Requires initial calibration after a known full charge.
      BOM: INA260 #4226 + STEMMA QT cable.
 
-  3. Unavailable
-     Neither sensor detected. Returns battery_pct=None; callers omit the
+  3. WittyPi output voltage (rough estimate — no extra hardware required)
+     The WittyPi 4 reports the voltage it delivers to the Raspberry Pi via
+     its 5V GPIO rail. This voltage droops slowly as the Voltaic V50 depletes
+     and rises when solar charging restores the pack. The relationship is
+     non-linear and load-dependent, so the estimate is coarse but useful for
+     detecting critically low charge without additional hardware.
+     Calibrate WITTYPI_OUTPUT_V_FULL / WITTYPI_OUTPUT_V_EMPTY against
+     observed readings at known charge levels.
+
+  4. Unavailable
+     No usable reading available. Returns battery_pct=None; callers omit the
      battery channel from transmissions rather than sending a wrong value.
 
 Wiring — ADS1115 path:
@@ -50,6 +59,13 @@ CELL_V_MAX = 4.2   # cell voltage at 100% SOC
 # ── INA260 constants ───────────────────────────────────────────────────────
 INA260_I2C_ADDRESS = 0x40
 VOLTAIC_V50_MAH = 13500.0
+
+# ── WittyPi output-voltage constants ──────────────────────────────────────
+# The WittyPi 5V output rail droops as the Voltaic V50 depletes. These
+# bounds must be calibrated against observed readings at known charge levels.
+# The defaults below are conservative starting points; refine after deployment.
+WITTYPI_OUTPUT_V_FULL = 5.10   # output voltage (V) when battery is fully charged
+WITTYPI_OUTPUT_V_EMPTY = 4.75  # output voltage (V) when battery is nearly depleted
 # Stored in the project root so it stays within the home directory on all deployments.
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 STATE_FILE = os.path.join(_PROJECT_ROOT, "battery_state.json")
@@ -60,15 +76,21 @@ STATE_FILE = os.path.join(_PROJECT_ROOT, "battery_state.json")
 # ---------------------------------------------------------------------------
 
 def get_battery_status() -> dict:
-    """Return current battery SOC, trying ADS1115 then INA260 then unavailable.
+    """Return current battery SOC, trying each path in priority order.
+
+    Priority: ADS1115 D+ pin → INA260 coulomb counting →
+              WittyPi output voltage (rough) → unavailable.
 
     Return dict keys:
-        battery_pct     int | None   — 0–100, or None when unavailable
-        battery_source  str          — "ads1115_dplus" | "ina260" | "unavailable"
-        cell_voltage_v  float | None — reconstructed cell voltage (V); ADS1115 path only
-        d_plus_v        float | None — raw D+ reading (V); ADS1115 path only
-        current_ma      float | None — instantaneous draw (mA); INA260 path only
-        mah_remaining   float | None — coulomb-counted charge (mAh); INA260 path only
+        battery_pct      int | None   — 0–100, or None when unavailable
+        battery_source   str          — "ads1115_dplus" | "ina260" |
+                                        "wittypi_output" | "unavailable"
+        cell_voltage_v   float | None — reconstructed cell voltage (V); ADS1115 only
+        d_plus_v         float | None — raw D+ reading (V); ADS1115 only
+        current_ma       float | None — instantaneous draw (mA); INA260 only
+        mah_remaining    float | None — coulomb-counted charge (mAh); INA260 only
+        output_voltage_v float | None — WittyPi 5V rail reading (V); WittyPi path only
+        output_current_a float | None — WittyPi output current (A); WittyPi path only
     """
     # ── Path 1: ADS1115 + D+ ──────────────────────────────────────────────
     d_plus_v = _read_ads1115_dplus()
@@ -86,6 +108,8 @@ def get_battery_status() -> dict:
             "d_plus_v": round(d_plus_v, 4),
             "current_ma": None,
             "mah_remaining": None,
+            "output_voltage_v": None,
+            "output_current_a": None,
         }
 
     # ── Path 2: INA260 coulomb counting ───────────────────────────────────
@@ -108,10 +132,31 @@ def get_battery_status() -> dict:
             "d_plus_v": None,
             "current_ma": round(current_ma, 2),
             "mah_remaining": round(mah_remaining, 1),
+            "output_voltage_v": None,
+            "output_current_a": None,
         }
 
-    # ── Path 3: unavailable ───────────────────────────────────────────────
-    _log_wittypi_vin_diagnostic()
+    # ── Path 3: WittyPi output voltage (rough estimate) ───────────────────
+    wittypi_reading = _read_wittypi_output()
+    if wittypi_reading is not None:
+        output_v, output_a = wittypi_reading
+        battery_pct = _wittypi_output_to_pct(output_v)
+        logging.info(
+            "Battery (WittyPi output, rough): %d%% — %.3fV, %.3fA",
+            battery_pct, output_v, output_a,
+        )
+        return {
+            "battery_pct": battery_pct,
+            "battery_source": "wittypi_output",
+            "cell_voltage_v": None,
+            "d_plus_v": None,
+            "current_ma": None,
+            "mah_remaining": None,
+            "output_voltage_v": round(output_v, 3),
+            "output_current_a": round(output_a, 3),
+        }
+
+    # ── Path 4: unavailable ───────────────────────────────────────────────
     return {
         "battery_pct": None,
         "battery_source": "unavailable",
@@ -119,6 +164,8 @@ def get_battery_status() -> dict:
         "d_plus_v": None,
         "current_ma": None,
         "mah_remaining": None,
+        "output_voltage_v": None,
+        "output_current_a": None,
     }
 
 
@@ -230,20 +277,38 @@ def _save_state(state: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Diagnostic
+# WittyPi output-voltage interface
 # ---------------------------------------------------------------------------
 
-def _log_wittypi_vin_diagnostic() -> None:
-    """Log WittyPi VIN for cable-fault detection only — NOT an SOC signal.
+def _read_wittypi_output() -> Optional[tuple[float, float]]:
+    """Read output voltage (V) and current (A) from the WittyPi 4.
 
-    The Voltaic V50 outputs regulated 5V; VIN does not vary with charge level.
-    Values below ~4.5V may indicate a power cable fault.
+    Returns (output_voltage_v, output_current_a), or None if unavailable.
+    The output voltage is the 5V rail delivered to the Raspberry Pi and droops
+    gradually as the Voltaic V50 depletes, providing a rough SOC signal.
     """
     try:
         from tools.wittypi_control import get_wittypi_status
         data = get_wittypi_status()
-        vin = data.get("battery_voltage")
-        if vin is not None:
-            logging.debug("WittyPi VIN (cable diagnostic only): %.3fV", vin)
-    except Exception:
-        pass
+        if data.get("status") != "wittypi_data_retrieved":
+            return None
+        output_v = data.get("internal_voltage")
+        output_a = data.get("internal_current", 0.0)
+        if output_v is None or output_v <= 0:
+            return None
+        return float(output_v), float(output_a)
+    except Exception as e:
+        logging.debug("WittyPi output read failed: %s", e)
+        return None
+
+
+def _wittypi_output_to_pct(output_v: float) -> int:
+    """Estimate SOC from WittyPi output voltage, clamped [0, 100].
+
+    The mapping is linear between WITTYPI_OUTPUT_V_EMPTY and
+    WITTYPI_OUTPUT_V_FULL. Accuracy is limited because the output voltage
+    also varies with load current. Treat results as a rough indicator only.
+    Calibrate the constants against observed voltages at known charge levels.
+    """
+    pct = (output_v - WITTYPI_OUTPUT_V_EMPTY) / (WITTYPI_OUTPUT_V_FULL - WITTYPI_OUTPUT_V_EMPTY) * 100
+    return max(0, min(100, int(pct)))

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -1,177 +1,116 @@
 """
 Battery state-of-charge estimation for the UFONet HazMapper WaterCam unit.
 
-Hardware: Voltaic V50 battery pack (50 Wh, ~13 500 mAh at 3.7 V nominal).
-The V50 outputs regulated 5 V USB — raw cell voltage is not exposed.
-SOC is estimated via coulomb counting using an Adafruit INA260 power monitor
-(Product #4226) placed in-line on the power feed from the Voltaic V50 to the
-WittyPi 4 input.
+Hardware: Voltaic V50 battery pack (50 Wh).
+Method: read the D+ pin on the Voltaic V50 USB-C output port, which carries
+approximately half the internal cell voltage. This signal varies linearly with
+SOC and is read by an Adafruit ADS1115 16-bit ADC (Product #1085) over I2C.
 
-Without an INA260 the module returns battery_source="unavailable" and
-battery_pct=None so callers can omit the battery channel from transmissions
-rather than sending a wrong value.
+Reference: https://blog.voltaicsystems.com/reading-charge-level-of-voltaic-usb-battery-packs/
+
+Wiring:
+  Voltaic V50 USB-C D+ ──► ADS1115 AIN0
+  ADS1115 SDA/SCL ────────► RPi GPIO 2/3 (shared I2C1 bus)
+
+Without an ADS1115, returns battery_source="unavailable" and battery_pct=None
+so callers omit the battery channel from transmissions rather than sending a
+wrong value derived from the regulated 5V WittyPi VIN.
 """
 
-import json
 import logging
-import os
-from datetime import datetime, timezone
 from typing import Optional
 
-STATE_FILE = "/var/lib/watercam/battery_state.json"
-VOLTAIC_V50_MAH = 13500.0
-INA260_I2C_ADDRESS = 0x40
+ADS1115_I2C_ADDRESS = 0x48
+
+# LiPo cell voltage bounds for the Voltaic V50.
+# D+ carries ~½ cell voltage; reconstructed cell voltage is compared to these.
+# Tune with empirical D+ readings from the deployed unit if needed.
+CELL_V_MIN = 3.0   # cell voltage at 0% SOC
+CELL_V_MAX = 4.2   # cell voltage at 100% SOC
 
 
 def get_battery_status() -> dict:
-    """Return current battery state-of-charge and supporting diagnostics.
+    """Return current battery state-of-charge from the Voltaic V50 D+ pin.
 
     Returns a dict with keys:
-        battery_pct      int | None   — 0-100, or None if unavailable
-        battery_source   str          — "ina260" or "unavailable"
-        input_voltage_v  float | None — raw INA260 bus voltage (V)
-        current_ma       float | None — instantaneous current draw (mA)
-        mah_remaining    float | None — coulomb-counted remaining charge
+        battery_pct     int | None   — 0–100, or None when unavailable
+        battery_source  str          — "ads1115_dplus" or "unavailable"
+        cell_voltage_v  float | None — reconstructed cell voltage (V)
+        d_plus_v        float | None — raw D+ pin reading (V)
     """
-    ina_reading = _read_ina260()
-    if ina_reading is None:
+    d_plus_v = _read_ads1115_dplus()
+    if d_plus_v is None:
         _log_wittypi_vin_diagnostic()
         return {
             "battery_pct": None,
             "battery_source": "unavailable",
-            "input_voltage_v": None,
-            "current_ma": None,
-            "mah_remaining": None,
+            "cell_voltage_v": None,
+            "d_plus_v": None,
         }
 
-    voltage_v, current_ma, _ = ina_reading
-    state = _load_state()
-    elapsed_s = _elapsed_seconds_since(state.get("last_updated_utc"))
-    mah_remaining = _update_coulomb_state(state, current_ma, elapsed_s)
-    _save_state(state)
-
-    battery_pct = max(0, min(100, int(mah_remaining / VOLTAIC_V50_MAH * 100)))
+    cell_v = d_plus_v * 2.0
+    battery_pct = _cell_voltage_to_pct(cell_v)
     logging.info(
-        "Battery: %.1f mAh remaining (%.0f%%), %.3f V, %.1f mA",
-        mah_remaining, battery_pct, voltage_v, current_ma,
+        "Battery: %d%% (D+=%.3fV, cell≈%.3fV)", battery_pct, d_plus_v, cell_v
     )
     return {
         "battery_pct": battery_pct,
-        "battery_source": "ina260",
-        "input_voltage_v": voltage_v,
-        "current_ma": current_ma,
-        "mah_remaining": mah_remaining,
+        "battery_source": "ads1115_dplus",
+        "cell_voltage_v": round(cell_v, 3),
+        "d_plus_v": round(d_plus_v, 4),
     }
 
 
-def calibrate_full_charge() -> None:
-    """Reset coulomb counter to 100% (call when pack is known to be fully charged)."""
-    state = _load_state()
-    state["mah_remaining"] = VOLTAIC_V50_MAH
-    state["calibrated"] = True
-    state["last_updated_utc"] = datetime.now(timezone.utc).isoformat()
-    _save_state(state)
-    logging.info("Battery coulomb counter reset to full (%.0f mAh)", VOLTAIC_V50_MAH)
-
-
 # ---------------------------------------------------------------------------
-# INA260 hardware interface
+# ADS1115 hardware interface
 # ---------------------------------------------------------------------------
 
-def _read_ina260() -> Optional[tuple[float, float, float]]:
-    """Read voltage (V), current (mA), power (mW) from INA260 over I2C.
+def _read_ads1115_dplus() -> Optional[float]:
+    """Read D+ voltage (V) from ADS1115 AIN0 at ±2.048V gain.
 
-    Returns None if the INA260 is not detected (hardware not installed).
+    Returns None if the ADS1115 is not detected (hardware not installed).
     """
     try:
         import board  # type: ignore
         import busio  # type: ignore
-        import adafruit_ina260  # type: ignore
+        import adafruit_ads1x15.ads1115 as ADS  # type: ignore
+        from adafruit_ads1x15.analog_in import AnalogIn  # type: ignore
 
         i2c = busio.I2C(board.SCL, board.SDA)
-        ina = adafruit_ina260.INA260(i2c, address=INA260_I2C_ADDRESS)
-        voltage_v = ina.voltage
-        current_ma = ina.current
-        power_mw = ina.power
-        return float(voltage_v), float(current_ma), float(power_mw)
+        ads = ADS.ADS1115(i2c, address=ADS1115_I2C_ADDRESS)
+        ads.gain = 2  # ±2.048V range — best resolution for 1.5–2.1V D+ signal
+        chan = AnalogIn(ads, ADS.P0)
+        return float(chan.voltage)
     except Exception as e:
-        logging.debug("INA260 not available: %s", e)
+        logging.debug("ADS1115 not available: %s", e)
         return None
 
 
-def _log_wittypi_vin_diagnostic() -> None:
-    """Log the raw WittyPi VIN reading for diagnostic purposes only.
+# ---------------------------------------------------------------------------
+# SOC calculation
+# ---------------------------------------------------------------------------
 
-    This value is ~5 V (regulated) when the Voltaic V50 is connected via
-    USB-C and does NOT reflect state of charge. It is logged only so that
-    unexpected VIN values (e.g. <4.5 V indicating a cable fault) appear in
-    system logs.
+def _cell_voltage_to_pct(cell_v: float) -> int:
+    """Convert reconstructed cell voltage to SOC percent, clamped [0, 100]."""
+    pct = (cell_v - CELL_V_MIN) / (CELL_V_MAX - CELL_V_MIN) * 100
+    return max(0, min(100, int(pct)))
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic
+# ---------------------------------------------------------------------------
+
+def _log_wittypi_vin_diagnostic() -> None:
+    """Log the WittyPi VIN reading for cable-fault detection only.
+
+    The Voltaic V50 outputs regulated 5V; this reading does NOT indicate SOC.
+    Unexpected values (e.g. <4.5V) may indicate a power cable fault.
     """
     try:
         from tools.wittypi_control import get_wittypi_status
         data = get_wittypi_status()
-        vin = data.get("battery_voltage", None)
+        vin = data.get("battery_voltage")
         if vin is not None:
-            logging.debug("WittyPi VIN (diagnostic only, not SOC): %.3f V", vin)
+            logging.debug("WittyPi VIN (cable diagnostic only, not SOC): %.3fV", vin)
     except Exception:
         pass
-
-
-# ---------------------------------------------------------------------------
-# Coulomb counting
-# ---------------------------------------------------------------------------
-
-def _update_coulomb_state(state: dict, current_ma: float, elapsed_s: float) -> float:
-    """Subtract consumed mAh from state and return updated mah_remaining."""
-    if elapsed_s <= 0:
-        return state.get("mah_remaining", VOLTAIC_V50_MAH)
-
-    elapsed_h = elapsed_s / 3600.0
-    # current_ma is draw from battery; positive = discharging
-    mah_consumed = current_ma * elapsed_h
-    mah_remaining = state.get("mah_remaining", VOLTAIC_V50_MAH) - mah_consumed
-    mah_remaining = max(0.0, min(VOLTAIC_V50_MAH, mah_remaining))
-
-    state["mah_remaining"] = mah_remaining
-    state["last_updated_utc"] = datetime.now(timezone.utc).isoformat()
-    return mah_remaining
-
-
-def _elapsed_seconds_since(iso_timestamp: Optional[str]) -> float:
-    """Return seconds elapsed since iso_timestamp, or 0 if unknown/invalid."""
-    if not iso_timestamp:
-        return 0.0
-    try:
-        last = datetime.fromisoformat(iso_timestamp)
-        now = datetime.now(timezone.utc)
-        delta = (now - last).total_seconds()
-        return max(0.0, delta)
-    except Exception:
-        return 0.0
-
-
-# ---------------------------------------------------------------------------
-# State persistence
-# ---------------------------------------------------------------------------
-
-def _load_state() -> dict:
-    try:
-        with open(STATE_FILE, "r", encoding="utf-8") as f:
-            state = json.load(f)
-        if "mah_remaining" not in state:
-            state["mah_remaining"] = VOLTAIC_V50_MAH
-        return state
-    except FileNotFoundError:
-        return {"mah_remaining": VOLTAIC_V50_MAH, "calibrated": False, "last_updated_utc": None}
-    except Exception as e:
-        logging.warning("Could not load battery state: %s — starting fresh", e)
-        return {"mah_remaining": VOLTAIC_V50_MAH, "calibrated": False, "last_updated_utc": None}
-
-
-def _save_state(state: dict) -> None:
-    try:
-        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
-        with open(STATE_FILE, "w", encoding="utf-8") as f:
-            json.dump(state, f, indent=2)
-    except Exception as e:
-        logging.warning("Could not save battery state: %s", e)

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -70,6 +70,10 @@ WITTYPI_OUTPUT_V_EMPTY = 4.75  # output voltage (V) when battery is nearly deple
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 STATE_FILE = os.path.join(_PROJECT_ROOT, "battery_state.json")
 
+# Module-level sensor cache — initialized on first successful read, reset on failure.
+_ads1115_chan = None   # adafruit_ads1x15.analog_in.AnalogIn
+_ina260 = None        # adafruit_ina260.INA260
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -192,19 +196,23 @@ def calibrate_full_charge() -> None:
 def _read_ads1115_dplus() -> Optional[float]:
     """Read D+ voltage (V) from ADS1115 AIN0 at ±2.048V gain.
 
-    Returns None if the ADS1115 is not detected.
+    Caches the AnalogIn instance at module scope after the first successful
+    initialisation. Resets the cache on any hardware error so the next call
+    retries. Returns None if the ADS1115 is not detected.
     """
+    global _ads1115_chan
     try:
-        import board  # type: ignore
-        import adafruit_ads1x15.ads1115 as ADS  # type: ignore
-        from adafruit_ads1x15.analog_in import AnalogIn  # type: ignore
-
-        i2c = board.I2C()
-        ads = ADS.ADS1115(i2c, address=ADS1115_I2C_ADDRESS)
-        ads.gain = 2  # ±2.048V — best resolution for 1.5–2.1V D+ signal
-        chan = AnalogIn(ads, ADS.P0)
-        return float(chan.voltage)
+        if _ads1115_chan is None:
+            import board  # type: ignore
+            import adafruit_ads1x15.ads1115 as ADS  # type: ignore
+            from adafruit_ads1x15.analog_in import AnalogIn  # type: ignore
+            i2c = board.I2C()
+            ads = ADS.ADS1115(i2c, address=ADS1115_I2C_ADDRESS)
+            ads.gain = 2  # ±2.048V — best resolution for 1.5–2.1V D+ signal
+            _ads1115_chan = AnalogIn(ads, ADS.P0)
+        return float(_ads1115_chan.voltage)
     except Exception as e:
+        _ads1115_chan = None  # reset so next call retries
         logging.debug("ADS1115 not available: %s", e)
         return None
 
@@ -222,16 +230,20 @@ def _cell_voltage_to_pct(cell_v: float) -> int:
 def _read_ina260() -> Optional[tuple[float, float, float]]:
     """Read voltage (V), current (mA), power (mW) from INA260 over I2C.
 
-    Returns None if the INA260 is not detected.
+    Caches the INA260 instance at module scope after the first successful
+    initialisation. Resets the cache on any hardware error so the next call
+    retries. Returns None if the INA260 is not detected.
     """
+    global _ina260
     try:
-        import board  # type: ignore
-        import adafruit_ina260  # type: ignore
-
-        i2c = board.I2C()
-        ina = adafruit_ina260.INA260(i2c, address=INA260_I2C_ADDRESS)
-        return float(ina.voltage), float(ina.current), float(ina.power)
+        if _ina260 is None:
+            import board  # type: ignore
+            import adafruit_ina260  # type: ignore
+            i2c = board.I2C()
+            _ina260 = adafruit_ina260.INA260(i2c, address=INA260_I2C_ADDRESS)
+        return float(_ina260.voltage), float(_ina260.current), float(_ina260.power)
     except Exception as e:
+        _ina260 = None  # reset so next call retries
         logging.debug("INA260 not available: %s", e)
         return None
 

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -75,11 +75,17 @@ STATE_FILE = os.path.join(_PROJECT_ROOT, "battery_state.json")
 # Public API
 # ---------------------------------------------------------------------------
 
-def get_battery_status() -> dict:
+def get_battery_status(wittypi_data: Optional[dict] = None) -> dict:
     """Return current battery SOC, trying each path in priority order.
 
     Priority: ADS1115 D+ pin → INA260 coulomb counting →
               WittyPi output voltage (rough) → unavailable.
+
+    Args:
+        wittypi_data: Optional pre-fetched result from get_wittypi_status().
+                      When supplied, Path 3 reuses it instead of making a
+                      second I2C call (avoids bus contention when the caller
+                      already holds fresh WittyPi readings).
 
     Return dict keys:
         battery_pct      int | None   — 0–100, or None when unavailable
@@ -137,7 +143,7 @@ def get_battery_status() -> dict:
         }
 
     # ── Path 3: WittyPi output voltage (rough estimate) ───────────────────
-    wittypi_reading = _read_wittypi_output()
+    wittypi_reading = _read_wittypi_output(wittypi_data)
     if wittypi_reading is not None:
         output_v, output_a = wittypi_reading
         battery_pct = _wittypi_output_to_pct(output_v)
@@ -282,16 +288,23 @@ def _save_state(state: dict) -> None:
 # WittyPi output-voltage interface
 # ---------------------------------------------------------------------------
 
-def _read_wittypi_output() -> Optional[tuple[float, float]]:
+def _read_wittypi_output(prefetched: Optional[dict] = None) -> Optional[tuple[float, float]]:
     """Read output voltage (V) and current (A) from the WittyPi 4.
 
     Returns (output_voltage_v, output_current_a), or None if unavailable.
     The output voltage is the 5V rail delivered to the Raspberry Pi and droops
     gradually as the Voltaic V50 depletes, providing a rough SOC signal.
+
+    Args:
+        prefetched: Optional result already returned by get_wittypi_status().
+                    Skips the I2C call when supplied.
     """
     try:
-        from tools.wittypi_control import get_wittypi_status
-        data = get_wittypi_status()
+        if prefetched is not None:
+            data = prefetched
+        else:
+            from tools.wittypi_control import get_wittypi_status
+            data = get_wittypi_status()
         if data.get("status") != "wittypi_data_retrieved":
             return None
         output_v = data.get("internal_voltage")

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -190,11 +190,10 @@ def _read_ads1115_dplus() -> Optional[float]:
     """
     try:
         import board  # type: ignore
-        import busio  # type: ignore
         import adafruit_ads1x15.ads1115 as ADS  # type: ignore
         from adafruit_ads1x15.analog_in import AnalogIn  # type: ignore
 
-        i2c = busio.I2C(board.SCL, board.SDA)
+        i2c = board.I2C()
         ads = ADS.ADS1115(i2c, address=ADS1115_I2C_ADDRESS)
         ads.gain = 2  # ±2.048V — best resolution for 1.5–2.1V D+ signal
         chan = AnalogIn(ads, ADS.P0)
@@ -221,10 +220,9 @@ def _read_ina260() -> Optional[tuple[float, float, float]]:
     """
     try:
         import board  # type: ignore
-        import busio  # type: ignore
         import adafruit_ina260  # type: ignore
 
-        i2c = busio.I2C(board.SCL, board.SDA)
+        i2c = board.I2C()
         ina = adafruit_ina260.INA260(i2c, address=INA260_I2C_ADDRESS)
         return float(ina.voltage), float(ina.current), float(ina.power)
     except Exception as e:
@@ -272,8 +270,10 @@ def _load_state() -> dict:
 
 def _save_state(state: dict) -> None:
     try:
-        with open(STATE_FILE, "w", encoding="utf-8") as f:
+        tmp = STATE_FILE + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2)
+        os.replace(tmp, STATE_FILE)
     except Exception as e:
         logging.warning("Could not save battery state: %s", e)
 

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -250,6 +250,8 @@ def _elapsed_seconds_since(iso_timestamp: Optional[str]) -> float:
         return 0.0
     try:
         last = datetime.fromisoformat(iso_timestamp)
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
         return max(0.0, (datetime.now(timezone.utc) - last).total_seconds())
     except Exception:
         return 0.0

--- a/tools/battery_manager.py
+++ b/tools/battery_manager.py
@@ -1,74 +1,143 @@
 """
 Battery state-of-charge estimation for the UFONet HazMapper WaterCam unit.
 
-Hardware: Voltaic V50 battery pack (50 Wh).
-Method: read the D+ pin on the Voltaic V50 USB-C output port, which carries
-approximately half the internal cell voltage. This signal varies linearly with
-SOC and is read by an Adafruit ADS1115 16-bit ADC (Product #1085) over I2C.
+Hardware: Voltaic V50 battery pack (50 Wh, ~13 500 mAh at 3.7 V nominal).
 
-Reference: https://blog.voltaicsystems.com/reading-charge-level-of-voltaic-usb-battery-packs/
+Two measurement paths are supported, tried in priority order:
 
-Wiring:
+  1. ADS1115 + D+ pin (preferred)
+     The Voltaic V50 outputs ~½ cell voltage on its USB-C D+ pin (1.5–2.1 V).
+     An Adafruit ADS1115 ADC (Product #1085) reads this directly.
+     No drift, no state file, fresh reading every boot.
+     Ref: https://blog.voltaicsystems.com/reading-charge-level-of-voltaic-usb-battery-packs/
+     BOM: ADS1115 #1085 + USB-C breakout #4090 + STEMMA QT cable.
+
+  2. INA260 coulomb counting (fallback)
+     An Adafruit INA260 power monitor (Product #4226) placed in-line on the
+     power feed measures current draw. Accumulated mAh is persisted to a state
+     file so the counter survives WittyPi-scheduled reboots.
+     Requires initial calibration after a known full charge.
+     BOM: INA260 #4226 + STEMMA QT cable.
+
+  3. Unavailable
+     Neither sensor detected. Returns battery_pct=None; callers omit the
+     battery channel from transmissions rather than sending a wrong value.
+
+Wiring — ADS1115 path:
   Voltaic V50 USB-C D+ ──► ADS1115 AIN0
   ADS1115 SDA/SCL ────────► RPi GPIO 2/3 (shared I2C1 bus)
 
-Without an ADS1115, returns battery_source="unavailable" and battery_pct=None
-so callers omit the battery channel from transmissions rather than sending a
-wrong value derived from the regulated 5V WittyPi VIN.
+Wiring — INA260 path:
+  Voltaic V50 5V out ──► INA260 Vin+ ──shunt──► INA260 Vin− ──► WittyPi
+  INA260 SDA/SCL ──────► RPi GPIO 2/3 (shared I2C1 bus)
 """
 
+import json
 import logging
+import os
+from datetime import datetime, timezone
 from typing import Optional
 
+# ── ADS1115 constants ──────────────────────────────────────────────────────
 ADS1115_I2C_ADDRESS = 0x48
 
 # LiPo cell voltage bounds for the Voltaic V50.
 # D+ carries ~½ cell voltage; reconstructed cell voltage is compared to these.
-# Tune with empirical D+ readings from the deployed unit if needed.
+# Tune with empirical D+ readings once the unit is deployed.
 CELL_V_MIN = 3.0   # cell voltage at 0% SOC
 CELL_V_MAX = 4.2   # cell voltage at 100% SOC
 
-
-def get_battery_status() -> dict:
-    """Return current battery state-of-charge from the Voltaic V50 D+ pin.
-
-    Returns a dict with keys:
-        battery_pct     int | None   — 0–100, or None when unavailable
-        battery_source  str          — "ads1115_dplus" or "unavailable"
-        cell_voltage_v  float | None — reconstructed cell voltage (V)
-        d_plus_v        float | None — raw D+ pin reading (V)
-    """
-    d_plus_v = _read_ads1115_dplus()
-    if d_plus_v is None:
-        _log_wittypi_vin_diagnostic()
-        return {
-            "battery_pct": None,
-            "battery_source": "unavailable",
-            "cell_voltage_v": None,
-            "d_plus_v": None,
-        }
-
-    cell_v = d_plus_v * 2.0
-    battery_pct = _cell_voltage_to_pct(cell_v)
-    logging.info(
-        "Battery: %d%% (D+=%.3fV, cell≈%.3fV)", battery_pct, d_plus_v, cell_v
-    )
-    return {
-        "battery_pct": battery_pct,
-        "battery_source": "ads1115_dplus",
-        "cell_voltage_v": round(cell_v, 3),
-        "d_plus_v": round(d_plus_v, 4),
-    }
+# ── INA260 constants ───────────────────────────────────────────────────────
+INA260_I2C_ADDRESS = 0x40
+VOLTAIC_V50_MAH = 13500.0
+STATE_FILE = "/var/lib/watercam/battery_state.json"
 
 
 # ---------------------------------------------------------------------------
-# ADS1115 hardware interface
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_battery_status() -> dict:
+    """Return current battery SOC, trying ADS1115 then INA260 then unavailable.
+
+    Return dict keys:
+        battery_pct     int | None   — 0–100, or None when unavailable
+        battery_source  str          — "ads1115_dplus" | "ina260" | "unavailable"
+        cell_voltage_v  float | None — reconstructed cell voltage (V); ADS1115 path only
+        d_plus_v        float | None — raw D+ reading (V); ADS1115 path only
+        current_ma      float | None — instantaneous draw (mA); INA260 path only
+        mah_remaining   float | None — coulomb-counted charge (mAh); INA260 path only
+    """
+    # ── Path 1: ADS1115 + D+ ──────────────────────────────────────────────
+    d_plus_v = _read_ads1115_dplus()
+    if d_plus_v is not None:
+        cell_v = d_plus_v * 2.0
+        battery_pct = _cell_voltage_to_pct(cell_v)
+        logging.info(
+            "Battery (ADS1115): %d%% — D+=%.3fV cell≈%.3fV",
+            battery_pct, d_plus_v, cell_v,
+        )
+        return {
+            "battery_pct": battery_pct,
+            "battery_source": "ads1115_dplus",
+            "cell_voltage_v": round(cell_v, 3),
+            "d_plus_v": round(d_plus_v, 4),
+            "current_ma": None,
+            "mah_remaining": None,
+        }
+
+    # ── Path 2: INA260 coulomb counting ───────────────────────────────────
+    ina_reading = _read_ina260()
+    if ina_reading is not None:
+        voltage_v, current_ma, _ = ina_reading
+        state = _load_state()
+        elapsed_s = _elapsed_seconds_since(state.get("last_updated_utc"))
+        mah_remaining = _update_coulomb_state(state, current_ma, elapsed_s)
+        _save_state(state)
+        battery_pct = max(0, min(100, int(mah_remaining / VOLTAIC_V50_MAH * 100)))
+        logging.info(
+            "Battery (INA260): %d%% — %.1f mAh remaining, %.3fV, %.1f mA",
+            battery_pct, mah_remaining, voltage_v, current_ma,
+        )
+        return {
+            "battery_pct": battery_pct,
+            "battery_source": "ina260",
+            "cell_voltage_v": None,
+            "d_plus_v": None,
+            "current_ma": round(current_ma, 2),
+            "mah_remaining": round(mah_remaining, 1),
+        }
+
+    # ── Path 3: unavailable ───────────────────────────────────────────────
+    _log_wittypi_vin_diagnostic()
+    return {
+        "battery_pct": None,
+        "battery_source": "unavailable",
+        "cell_voltage_v": None,
+        "d_plus_v": None,
+        "current_ma": None,
+        "mah_remaining": None,
+    }
+
+
+def calibrate_full_charge() -> None:
+    """Reset INA260 coulomb counter to 100% (call when pack is known fully charged)."""
+    state = _load_state()
+    state["mah_remaining"] = VOLTAIC_V50_MAH
+    state["calibrated"] = True
+    state["last_updated_utc"] = datetime.now(timezone.utc).isoformat()
+    _save_state(state)
+    logging.info("INA260 coulomb counter reset to full (%.0f mAh)", VOLTAIC_V50_MAH)
+
+
+# ---------------------------------------------------------------------------
+# ADS1115 interface
 # ---------------------------------------------------------------------------
 
 def _read_ads1115_dplus() -> Optional[float]:
     """Read D+ voltage (V) from ADS1115 AIN0 at ±2.048V gain.
 
-    Returns None if the ADS1115 is not detected (hardware not installed).
+    Returns None if the ADS1115 is not detected.
     """
     try:
         import board  # type: ignore
@@ -78,17 +147,13 @@ def _read_ads1115_dplus() -> Optional[float]:
 
         i2c = busio.I2C(board.SCL, board.SDA)
         ads = ADS.ADS1115(i2c, address=ADS1115_I2C_ADDRESS)
-        ads.gain = 2  # ±2.048V range — best resolution for 1.5–2.1V D+ signal
+        ads.gain = 2  # ±2.048V — best resolution for 1.5–2.1V D+ signal
         chan = AnalogIn(ads, ADS.P0)
         return float(chan.voltage)
     except Exception as e:
         logging.debug("ADS1115 not available: %s", e)
         return None
 
-
-# ---------------------------------------------------------------------------
-# SOC calculation
-# ---------------------------------------------------------------------------
 
 def _cell_voltage_to_pct(cell_v: float) -> int:
     """Convert reconstructed cell voltage to SOC percent, clamped [0, 100]."""
@@ -97,20 +162,87 @@ def _cell_voltage_to_pct(cell_v: float) -> int:
 
 
 # ---------------------------------------------------------------------------
+# INA260 interface
+# ---------------------------------------------------------------------------
+
+def _read_ina260() -> Optional[tuple[float, float, float]]:
+    """Read voltage (V), current (mA), power (mW) from INA260 over I2C.
+
+    Returns None if the INA260 is not detected.
+    """
+    try:
+        import board  # type: ignore
+        import busio  # type: ignore
+        import adafruit_ina260  # type: ignore
+
+        i2c = busio.I2C(board.SCL, board.SDA)
+        ina = adafruit_ina260.INA260(i2c, address=INA260_I2C_ADDRESS)
+        return float(ina.voltage), float(ina.current), float(ina.power)
+    except Exception as e:
+        logging.debug("INA260 not available: %s", e)
+        return None
+
+
+def _update_coulomb_state(state: dict, current_ma: float, elapsed_s: float) -> float:
+    """Subtract consumed mAh from state, update timestamp, return mah_remaining."""
+    if elapsed_s > 0:
+        mah_consumed = current_ma * (elapsed_s / 3600.0)
+        state["mah_remaining"] = max(
+            0.0,
+            min(VOLTAIC_V50_MAH, state.get("mah_remaining", VOLTAIC_V50_MAH) - mah_consumed),
+        )
+    state["last_updated_utc"] = datetime.now(timezone.utc).isoformat()
+    return state["mah_remaining"]
+
+
+def _elapsed_seconds_since(iso_timestamp: Optional[str]) -> float:
+    """Return seconds elapsed since iso_timestamp, or 0 if unknown/invalid."""
+    if not iso_timestamp:
+        return 0.0
+    try:
+        last = datetime.fromisoformat(iso_timestamp)
+        return max(0.0, (datetime.now(timezone.utc) - last).total_seconds())
+    except Exception:
+        return 0.0
+
+
+def _load_state() -> dict:
+    try:
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            state = json.load(f)
+        state.setdefault("mah_remaining", VOLTAIC_V50_MAH)
+        return state
+    except FileNotFoundError:
+        return {"mah_remaining": VOLTAIC_V50_MAH, "calibrated": False, "last_updated_utc": None}
+    except Exception as e:
+        logging.warning("Could not load battery state: %s — starting fresh", e)
+        return {"mah_remaining": VOLTAIC_V50_MAH, "calibrated": False, "last_updated_utc": None}
+
+
+def _save_state(state: dict) -> None:
+    try:
+        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+        with open(STATE_FILE, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+    except Exception as e:
+        logging.warning("Could not save battery state: %s", e)
+
+
+# ---------------------------------------------------------------------------
 # Diagnostic
 # ---------------------------------------------------------------------------
 
 def _log_wittypi_vin_diagnostic() -> None:
-    """Log the WittyPi VIN reading for cable-fault detection only.
+    """Log WittyPi VIN for cable-fault detection only — NOT an SOC signal.
 
-    The Voltaic V50 outputs regulated 5V; this reading does NOT indicate SOC.
-    Unexpected values (e.g. <4.5V) may indicate a power cable fault.
+    The Voltaic V50 outputs regulated 5V; VIN does not vary with charge level.
+    Values below ~4.5V may indicate a power cable fault.
     """
     try:
         from tools.wittypi_control import get_wittypi_status
         data = get_wittypi_status()
         vin = data.get("battery_voltage")
         if vin is not None:
-            logging.debug("WittyPi VIN (cable diagnostic only, not SOC): %.3fV", vin)
+            logging.debug("WittyPi VIN (cable diagnostic only): %.3fV", vin)
     except Exception:
         pass

--- a/tools/debug_status_command.py
+++ b/tools/debug_status_command.py
@@ -244,13 +244,14 @@ def get_wittypi_status() -> Dict[str, Any]:
         
         # If hardware is present, try to get data
         from wittypi_control import get_data
-        temperature, battery_voltage, internal_voltage = get_data()
-        
+        temperature, battery_voltage, internal_voltage, internal_current = get_data()
+
         return {
             'available': True,
             'temperature_c': temperature,
             'battery_voltage_v': battery_voltage,
             'internal_voltage_v': internal_voltage,
+            'internal_current_a': internal_current,
             'status': 'wittypi_available',
             'i2c_address': '0x08'
         }

--- a/tools/initial_health_check.py
+++ b/tools/initial_health_check.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+"""
+Initial system health check for SU-WaterCam
+
+Runs once at startup to validate:
+- CPU temperature
+- WittyPi input/battery/internal voltages
+- GPS location availability
+- IMU orientation availability
+
+On any failure, sends a LoRa packet describing the failed checks.
+
+This script is intended to be invoked manually or from a systemd unit/boot script
+before the main application loop. It exits 0 on success, 1 on failure (after
+attempting to send the LoRa alert).
+"""
+
+from typing import Dict, Any, List
+import math
+
+
+def read_cpu_temperature_c() -> float:
+    """Return CPU temperature in Celsius, or math.nan if unavailable."""
+    try:
+        import subprocess
+        result = subprocess.run(['vcgencmd', 'measure_temp'], capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            temp_str = result.stdout.strip()
+            # Expected format: temp=45.2'C
+            value = float(temp_str.split('=')[1].split("'")[0])
+            return value
+    except Exception:
+        pass
+    return math.nan
+
+
+def read_wittypi_voltages() -> Dict[str, float]:
+    """Return voltages from WittyPi or empty dict if unavailable."""
+    try:
+        from tools.wittypi_control import get_data
+        temperature_c, battery_voltage_v, internal_voltage_v, internal_current_a = get_data()
+        return {
+            'wittypi_temperature_c': float(temperature_c),
+            'wittypi_battery_voltage_v': float(battery_voltage_v),
+            'wittypi_internal_voltage_v': float(internal_voltage_v),
+            'wittypi_internal_current_a': float(internal_current_a),
+        }
+    except Exception:
+        return {}
+
+
+def read_gps_location() -> Dict[str, Any]:
+    """Return GPS lat/lon/alt dict if available, else empty dict."""
+    try:
+        from tools.get_gps import get_lat_lon_alt
+        gps = get_lat_lon_alt()
+        return gps if isinstance(gps, dict) else {}
+    except Exception:
+        return {}
+
+
+def read_imu_orientation() -> Dict[str, Any]:
+    """Return IMU orientation dict if available, else empty dict."""
+    try:
+        from tools.bno055_imu import get_orientation
+        orientation = get_orientation()
+        return orientation if isinstance(orientation, dict) else {}
+    except Exception:
+        return {}
+
+
+def evaluate_health(
+    cpu_temp_c: float,
+    wittypi: Dict[str, float],
+    gps: Dict[str, Any],
+    imu: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Compare readings against defaults and return status and reasons."""
+    failures: List[str] = []
+
+    # Thresholds (conservative defaults)
+    max_cpu_temp_c = 80.0
+    min_battery_voltage_v = 3.6
+    min_internal_voltage_v = 4.7
+
+    # CPU temp
+    if math.isnan(cpu_temp_c):
+        failures.append('cpu_temp_unavailable')
+    elif cpu_temp_c > max_cpu_temp_c:
+        failures.append(f'cpu_temp_high_{cpu_temp_c:.1f}C')
+
+    # WittyPi voltages
+    if not wittypi:
+        failures.append('wittypi_unavailable')
+    else:
+        bv = wittypi.get('wittypi_battery_voltage_v', math.nan)
+        iv = wittypi.get('wittypi_internal_voltage_v', math.nan)
+        if math.isnan(bv):
+            failures.append('battery_voltage_unavailable')
+        elif bv < min_battery_voltage_v:
+            failures.append(f'battery_voltage_low_{bv:.2f}V')
+        if math.isnan(iv):
+            failures.append('internal_voltage_unavailable')
+        elif iv < min_internal_voltage_v:
+            failures.append(f'internal_voltage_low_{iv:.2f}V')
+
+    # GPS
+    if not gps:
+        failures.append('gps_unavailable')
+    else:
+        lat = gps.get('lat') or gps.get('latitude')
+        lon = gps.get('lon') or gps.get('longitude')
+        if lat is None or lon is None:
+            failures.append('gps_invalid')
+
+    # IMU
+    if not imu:
+        failures.append('imu_unavailable')
+
+    status = 'fail' if failures else 'ok'
+    return {
+        'status': status,
+        'failures': failures,
+        'readings': {
+            'cpu_temp_c': cpu_temp_c if not math.isnan(cpu_temp_c) else None,
+            **({} if not wittypi else wittypi),
+            **({} if not gps else gps),
+            **({} if not imu else imu),
+        }
+    }
+
+
+def send_lora_alert(payload: Dict[str, Any]) -> bool:
+    """Send payload over LoRa, returning True on success."""
+    try:
+        from tools.lora_handler_concurrent import get_lora_handler
+        handler = get_lora_handler()
+        handler.queue_transmit({'health_check': payload})
+        handler.process_transmit_queue()
+        return True
+    except Exception:
+        return False
+
+
+def main() -> int:
+    cpu_temp_c = read_cpu_temperature_c()
+    wittypi = read_wittypi_voltages()
+    gps = read_gps_location()
+    imu = read_imu_orientation()
+
+    result = evaluate_health(cpu_temp_c, wittypi, gps, imu)
+
+    if result['status'] == 'fail':
+        sent = send_lora_alert(result)
+        # Best-effort; still return failure exit code
+        return 1 if not sent else 1
+    return 0
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())
+
+

--- a/tools/initial_health_check.py
+++ b/tools/initial_health_check.py
@@ -81,7 +81,10 @@ def evaluate_health(
 
     # Thresholds (conservative defaults)
     max_cpu_temp_c = 80.0
-    min_battery_voltage_v = 3.6
+    # wittypi_battery_voltage_v is the WittyPi VIN (regulated 5V USB from Voltaic V50).
+    # It stays near 5V until the pack dies, so the useful fault threshold is a cable/
+    # connection check (~4.5V) rather than a cell-voltage threshold.
+    min_input_voltage_v = 4.5
     min_internal_voltage_v = 4.7
 
     # CPU temp
@@ -97,9 +100,9 @@ def evaluate_health(
         bv = wittypi.get('wittypi_battery_voltage_v', math.nan)
         iv = wittypi.get('wittypi_internal_voltage_v', math.nan)
         if math.isnan(bv):
-            failures.append('battery_voltage_unavailable')
-        elif bv < min_battery_voltage_v:
-            failures.append(f'battery_voltage_low_{bv:.2f}V')
+            failures.append('wittypi_input_voltage_unavailable')
+        elif bv < min_input_voltage_v:
+            failures.append(f'wittypi_input_voltage_low_{bv:.2f}V')
         if math.isnan(iv):
             failures.append('internal_voltage_unavailable')
         elif iv < min_internal_voltage_v:
@@ -132,11 +135,21 @@ def evaluate_health(
 
 
 def send_lora_alert(payload: Dict[str, Any]) -> bool:
-    """Send payload over LoRa, returning True on success."""
+    """Encode health-check result as standard LoRa fields and transmit.
+
+    Uses emergency_status=1 and health_status=0 to signal failure.
+    The LoRa encoder ignores unknown top-level keys, so the full payload
+    dict is not transmitted; only the fields the encoder knows are included.
+    """
     try:
+        import time
         from tools.lora_handler_concurrent import get_lora_handler
         handler = get_lora_handler()
-        handler.queue_transmit({'health_check': payload})
+        handler.queue_transmit({
+            'timestamp': int(time.time()),
+            'emergency_status': 1,
+            'health_status': 0,
+        })
         handler.process_transmit_queue()
         return True
     except Exception:

--- a/tools/initial_health_check.py
+++ b/tools/initial_health_check.py
@@ -112,8 +112,8 @@ def evaluate_health(
     if not gps:
         failures.append('gps_unavailable')
     else:
-        lat = gps.get('lat') or gps.get('latitude')
-        lon = gps.get('lon') or gps.get('longitude')
+        lat = gps.get('gps_lat') or gps.get('lat') or gps.get('latitude')
+        lon = gps.get('gps_lon') or gps.get('lon') or gps.get('longitude')
         if lat is None or lon is None:
             failures.append('gps_invalid')
 
@@ -135,11 +135,12 @@ def evaluate_health(
 
 
 def send_lora_alert(payload: Dict[str, Any]) -> bool:
-    """Encode health-check result as standard LoRa fields and transmit.
+    """Transmit a minimal LoRa alert signalling health-check failure.
 
-    Uses emergency_status=1 and health_status=0 to signal failure.
-    The LoRa encoder ignores unknown top-level keys, so the full payload
-    dict is not transmitted; only the fields the encoder knows are included.
+    Sends timestamp, emergency_status=1, and health_status=0.
+    The full payload dict (failures list, readings) is NOT transmitted —
+    the LoRa encoder only encodes known channel fields, and failure details
+    would exceed the LoRa payload size limit.
     """
     try:
         import time

--- a/tools/initial_health_check.py
+++ b/tools/initial_health_check.py
@@ -134,11 +134,11 @@ def evaluate_health(
     }
 
 
-def send_lora_alert(payload: Dict[str, Any]) -> bool:
+def send_lora_alert() -> bool:
     """Transmit a minimal LoRa alert signalling health-check failure.
 
     Sends timestamp, emergency_status=1, and health_status=0.
-    The full payload dict (failures list, readings) is NOT transmitted —
+    Failure details (failures list, readings) are NOT transmitted —
     the LoRa encoder only encodes known channel fields, and failure details
     would exceed the LoRa payload size limit.
     """
@@ -166,9 +166,8 @@ def main() -> int:
     result = evaluate_health(cpu_temp_c, wittypi, gps, imu)
 
     if result['status'] == 'fail':
-        sent = send_lora_alert(result)
-        # Best-effort; still return failure exit code
-        return 1 if not sent else 1
+        send_lora_alert()
+        return 1
     return 0
 
 

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -588,7 +588,7 @@ class LoRaHandler:
             if 'movement_threshold' in data: 
                 print(f"DEBUG: Processing movement_threshold: {data['movement_threshold']}")
                 add_u8(0x01, 0x06, data['movement_threshold'])
-            if 'battery_percent' in data: 
+            if data.get('battery_percent') is not None:
                 print(f"DEBUG: Processing battery_percent: {data['battery_percent']}")
                 add_u8(0x02, 0x01, data['battery_percent'])
             if 'tilt_roll_yaw' in data: 

--- a/tools/lora_transmit.py
+++ b/tools/lora_transmit.py
@@ -79,7 +79,7 @@ def compressed_encoding(data):
     if 'emergency_status' in data: add_u8(0x01, 0x04, data['emergency_status'])
     if 'health_status' in data: add_u8(0x01, 0x05, data['health_status'])
     if 'movement_threshold' in data: add_u8(0x01, 0x06, data['movement_threshold'])
-    if 'battery_percent' in data: add_u8(0x02, 0x01, data['battery_percent'])
+    if data.get('battery_percent') is not None: add_u8(0x02, 0x01, data['battery_percent'])
     if 'tilt_roll_yaw' in data: add_f32_3(0x03, 0x01, data['tilt_roll_yaw'])
     if 'lat_lon_z' in data: add_f32_3(0x04, 0x01, data['lat_lon_z'])
     if 'temperature_celsius' in data: add_f32(0x05, 0x01, data['temperature_celsius'])

--- a/tools/wittypi_control.py
+++ b/tools/wittypi_control.py
@@ -28,7 +28,8 @@ from datetime import datetime, timezone
 @SQify
 def get_wittypi_status():
     """
-    Get current WittyPi status including temperature, battery voltage, and internal voltage
+    Get current WittyPi status including temperature, battery voltage,
+    internal voltage, and internal current.
     """
     try:
         temperature, battery_voltage, internal_voltage, internal_current = get_data()

--- a/tools/wittypi_control.py
+++ b/tools/wittypi_control.py
@@ -11,7 +11,8 @@ def get_data():
     temperature = witty_pi_4.get_temperature()
     battery_voltage = witty_pi_4.get_battery_voltage()
     internal_voltage = witty_pi_4.get_internal_voltage()
-    return temperature, battery_voltage, internal_voltage
+    internal_current = witty_pi_4.get_internal_current()
+    return temperature, battery_voltage, internal_voltage, internal_current
 
 def set_schedule(start_hour, start_minute, interval_length_minutes, num_repetitions_per_day):
     witty_pi_4.generate_schedule(start_hour, start_minute, interval_length_minutes, num_repetitions_per_day)
@@ -30,13 +31,14 @@ def get_wittypi_status():
     Get current WittyPi status including temperature, battery voltage, and internal voltage
     """
     try:
-        temperature, battery_voltage, internal_voltage = get_data()
-        
+        temperature, battery_voltage, internal_voltage, internal_current = get_data()
+
         return {
             'status': 'wittypi_data_retrieved',
             'temperature': temperature,
             'battery_voltage': battery_voltage,
             'internal_voltage': internal_voltage,
+            'internal_current': internal_current,
             'timestamp': datetime.now(timezone.utc).isoformat()
         }
         


### PR DESCRIPTION
Closes #46

## Background

Battery state-of-charge (SOC) was previously estimated by applying a single-cell LiPo formula to the WittyPi 4 `get_input_voltage` reading:

```python
batt_pct = max(0, min(100, int((batt_v - 3.0) / 1.2 * 100)))
```

This is physically wrong. The Voltaic V50 battery pack outputs **regulated 5 V USB-C** — `get_input_voltage` reads ~5 V at all charge levels, so the formula always returns 100% until the pack dies. Additionally, the LoRa transmit path never called `get_wittypi_status()` at all; `battery_percent` in LoRa packets was either absent or hardcoded from test fixtures.

## Root Cause Analysis

| Signal | What it actually reads | Useful for SOC? |
|---|---|---|
| `get_input_voltage` (WittyPi VIN) | Regulated 5 V USB output of Voltaic V50 | **No** — constant |
| `get_output_voltage` (WittyPi → RPi) | 5 V GPIO rail; droops slightly as pack depletes | **Rough estimate only** |
| Voltaic V50 USB-C D+ pin | ~½ × cell voltage (1.5–2.1 V, varies with SOC) | **Yes — accurate** |

Reference: https://blog.voltaicsystems.com/reading-charge-level-of-voltaic-usb-battery-packs/

## Changes

### New: `tools/battery_manager.py`

Single entry point `get_battery_status()` that tries three measurement paths in priority order, returning a consistent dict with `battery_source` indicating which path fired:

**Path 1 — ADS1115 + D+ pin** (`battery_source = "ads1115_dplus"`)
The Voltaic V50 exposes ~½ cell voltage on its USB-C D+ data pin. An Adafruit ADS1115 16-bit ADC (Product #1085, ±2.048 V gain) reads AIN0 connected to D+. Cell voltage is reconstructed as `D+ × 2` and mapped to SOC via the standard LiPo formula. No drift, no state file, fresh reading every boot.
- BOM: ADS1115 #1085 + USB-C breakout board #4090 + STEMMA QT cable
- Constants `CELL_V_MIN = 3.0 V`, `CELL_V_MAX = 4.2 V` are tunable once empirical D+ readings are collected from the deployed unit (Voltaic blog users report observed range 1.54–1.85 V, tighter than the theoretical 1.5–2.1 V)

**Path 2 — INA260 coulomb counting** (`battery_source = "ina260"`)
An Adafruit INA260 power monitor (Product #4226) placed in-line on the Voltaic V50 → WittyPi power feed measures instantaneous current draw. Accumulated mAh is persisted to `battery_state.json` in the project root (within home directory) so the counter survives WittyPi-scheduled reboots. SOC = `mah_remaining / 13500 × 100`.
- BOM: INA260 #4226 + STEMMA QT cable
- Requires `calibrate_full_charge()` to be called once after a known full charge; otherwise starts at 100% assumption
- `calibrate_full_charge()` is exposed as a public function for use in a future calibration workflow

**Path 3 — WittyPi output voltage** (`battery_source = "wittypi_output"`)
No additional hardware required. The WittyPi 4 `get_output_voltage` reading (5 V rail to Raspberry Pi) droops slowly as the Voltaic V50 depletes. Mapped linearly between `WITTYPI_OUTPUT_V_EMPTY = 4.75 V` (0%) and `WITTYPI_OUTPUT_V_FULL = 5.10 V` (100%). Both constants are tunable. Output current is also captured for diagnostics.
- Accuracy is limited: output voltage varies with load current as well as battery level. Treat as a coarse indicator, not a precise reading.
- This path is **active immediately** on the deployed unit before any new hardware arrives.

**Path 4 — Unavailable** (`battery_source = "unavailable"`, `battery_pct = None`)
All three paths failed. Callers omit the battery channel from transmissions rather than sending a wrong value.

### Modified: `tools/wittypi_control.py`

- `get_data()` now also calls `get_internal_current()`, returning a 4-tuple
- `get_wittypi_status()` dict gains `internal_current` key so `battery_manager` can read both voltage and current from a single WittyPi call

### Modified: `ticktalk_main.py`

- Both LoRa data-collection blocks (×2) and the IP uplink block: replaced the `get_wittypi_status()` → inline LiPo formula block with a call to `battery_manager.get_battery_status()`
- `wittypi_battery_voltage` key removed from `data` dict (was the wrong signal)
- `battery_percent` and `battery_source` now populated from `battery_manager`
- WittyPi block retains temperature and `internal_voltage` reads (these are still valid diagnostic values)

### Modified: `tools/lora_transmit.py` and `tools/lora_handler_concurrent.py`

- Both `compressed_encoding` implementations now use `data.get('battery_percent') is not None` instead of `'battery_percent' in data` — prevents encoding a `None` value as channel `02 01` when the battery reading is unavailable

### New: `docs/BATTERY_ESTIMATION_PLAN.md`

Design document covering hardware context, power chain diagram, voltage signal analysis, BOM, wiring diagrams, algorithm description, calibration notes, and implementation checklist.

### New: `tests/test_battery_manager.py`

48 tests covering:
- `_cell_voltage_to_pct`: bounds, midpoint, clamp, empirical observed range
- ADS1115 path: source tag, field values, cross-path field isolation
- INA260 path: discharge math, clamp, zero elapsed, source tag, state file roundtrip, missing-file defaults
- WittyPi output path: bounds, midpoint, clamp, field isolation, source tag
- Fallback chain: all 4 priority orderings verified (ADS1115 > INA260 > WittyPi > unavailable)
- LoRa packet encoding: `None` excluded, `0` included, valid value included

## Calibration Notes for Reviewer

The WittyPi output voltage path is immediately active. To get useful readings, the constants in `battery_manager.py` should be updated after observing output voltage at two known states:

```python
WITTYPI_OUTPUT_V_FULL = 5.10   # measure when Voltaic V50 is fully charged
WITTYPI_OUTPUT_V_EMPTY = 4.75  # measure just before pack protection trips
```

Similarly for the ADS1115 path once hardware arrives:
```python
CELL_V_MIN = 3.0  # may need raising to ~3.08 based on Voltaic blog empirical data
CELL_V_MAX = 4.2  # may need lowering to ~3.70 based on observed full-charge D+ reading
```

## Testing

```bash
python3 -m unittest tests.test_battery_manager -v
# Ran 48 tests in 0.007s — OK
```