### PR TITLE
fix: validate LoRa payload values against allowed ranges before apply…

### DIFF
--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -252,6 +252,12 @@ class TestSetParameterRanges(unittest.TestCase):
             result = self.mgr.set_parameter('area_threshold', 50)
             self.assertFalse(result)
 
+    def test_set_parameter_rolls_back_in_memory_on_save_failure(self):
+        self.mgr.set_parameter('area_threshold', 20)
+        with patch.object(self.mgr, 'save_parameters', return_value=False):
+            self.mgr.set_parameter('area_threshold', 50)
+        self.assertEqual(self.mgr.get_parameter('area_threshold'), 20)
+
     def test_set_parameter_returns_true_on_save_success(self):
         with patch.object(self.mgr, 'save_parameters', return_value=True):
             result = self.mgr.set_parameter('area_threshold', 50)

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -236,6 +236,27 @@ class TestSetParameterRanges(unittest.TestCase):
         self.assertIsInstance(result, int)
         self.assertEqual(result, 5)
 
+    # ---- overflow-safe float conversion ----------------------------------------
+
+    def test_very_large_int_rejected_without_overflow(self):
+        # int too large for float() raises OverflowError; must be caught and rejected
+        self.assertFalse(self.mgr.set_parameter('area_threshold', 10 ** 309))
+
+    def test_very_large_negative_int_rejected_without_overflow(self):
+        self.assertFalse(self.mgr.set_parameter('monitoring_frequency', -(10 ** 309)))
+
+    # ---- save_parameters failure propagates into set_parameter -----------------
+
+    def test_set_parameter_returns_false_on_save_failure(self):
+        with patch.object(self.mgr, 'save_parameters', return_value=False):
+            result = self.mgr.set_parameter('area_threshold', 50)
+            self.assertFalse(result)
+
+    def test_set_parameter_returns_true_on_save_success(self):
+        with patch.object(self.mgr, 'save_parameters', return_value=True):
+            result = self.mgr.set_parameter('area_threshold', 50)
+            self.assertTrue(result)
+
     # ---- set_parameter return value ------------------------------------------
 
     def test_set_parameter_returns_bool_true_on_success(self):

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -36,21 +36,22 @@ with patch.dict('sys.modules', {
     from lora_runtime_integration import LoRaRuntimeManager
 
 
-def _make_manager() -> LoRaRuntimeManager:
-    """Return a manager backed by a temp config file (no LoRa hardware)."""
-    with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
-        tmp = f.name
-
-    with patch.object(LoRaRuntimeManager, '_init_lora_handler', lambda self: None):
-        mgr = LoRaRuntimeManager(config_file=tmp)
-    mgr.lora_handler = None
-    return mgr
-
-
 class TestSetParameterRanges(unittest.TestCase):
 
     def setUp(self):
-        self.mgr = _make_manager()
+        fd, self._tmp_path = tempfile.mkstemp(suffix='.json')
+        os.close(fd)
+        with open(self._tmp_path, 'w') as f:
+            json.dump({}, f)
+        with patch.object(LoRaRuntimeManager, '_init_lora_handler', lambda self: None):
+            self.mgr = LoRaRuntimeManager(config_file=self._tmp_path)
+        self.mgr.lora_handler = None
+
+    def tearDown(self):
+        try:
+            os.unlink(self._tmp_path)
+        except OSError:
+            pass
 
     # ---- min/max inclusive acceptance ----------------------------------------
 

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -280,6 +280,15 @@ class TestSetParameterRanges(unittest.TestCase):
         self.mgr.set_parameter('area_threshold', 999)  # out of range
         self.assertEqual(self.mgr.get_parameter('area_threshold'), 20)
 
+    # ---- new-key rollback: key must not be left behind on save failure -------
+
+    def test_new_key_not_left_behind_on_save_failure(self):
+        # 'novel_param' does not exist in parameters before this call
+        self.mgr.parameters.pop('novel_param', None)
+        with patch.object(self.mgr, 'save_parameters', return_value=False):
+            self.mgr.set_parameter('novel_param', 'x')
+        self.assertNotIn('novel_param', self.mgr.parameters)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -67,7 +67,7 @@ class TestSetParameterRanges(unittest.TestCase):
         self.assertTrue(self.mgr.set_parameter('stage_threshold', 0))
 
     def test_stage_threshold_max_accepted(self):
-        self.assertTrue(self.mgr.set_parameter('stage_threshold', 1000))
+        self.assertTrue(self.mgr.set_parameter('stage_threshold', 255))
 
     def test_monitoring_frequency_min_accepted(self):
         self.assertTrue(self.mgr.set_parameter('monitoring_frequency', 1))
@@ -90,7 +90,7 @@ class TestSetParameterRanges(unittest.TestCase):
         self.assertFalse(self.mgr.set_parameter('area_threshold', 101))
 
     def test_stage_threshold_above_max_rejected(self):
-        self.assertFalse(self.mgr.set_parameter('stage_threshold', 1001))
+        self.assertFalse(self.mgr.set_parameter('stage_threshold', 256))
 
     def test_monitoring_frequency_zero_rejected(self):
         self.assertFalse(self.mgr.set_parameter('monitoring_frequency', 0))

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -211,6 +211,31 @@ class TestSetParameterRanges(unittest.TestCase):
         self.assertIsInstance(result, float)
         self.assertEqual(result, 100.0)
 
+    # ---- compression_level (1–10, integer) ------------------------------------
+
+    def test_compression_level_min_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('compression_level', 1))
+        self.assertEqual(self.mgr.get_parameter('compression_level'), 1)
+
+    def test_compression_level_max_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('compression_level', 10))
+        self.assertEqual(self.mgr.get_parameter('compression_level'), 10)
+
+    def test_compression_level_below_min_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('compression_level', 0))
+
+    def test_compression_level_above_max_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('compression_level', 11))
+
+    def test_compression_level_fractional_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('compression_level', 5.5))
+
+    def test_compression_level_stored_as_int(self):
+        self.mgr.set_parameter('compression_level', 5)
+        result = self.mgr.get_parameter('compression_level')
+        self.assertIsInstance(result, int)
+        self.assertEqual(result, 5)
+
     # ---- set_parameter return value ------------------------------------------
 
     def test_set_parameter_returns_bool_true_on_success(self):

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -125,6 +125,23 @@ class TestSetParameterRanges(unittest.TestCase):
     def test_stage_threshold_fractional_accepted(self):
         self.assertTrue(self.mgr.set_parameter('stage_threshold', 50.5))
 
+    # ---- inf/nan rejection (would crash int() without isfinite guard) ----------
+
+    def test_area_threshold_inf_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', float('inf')))
+
+    def test_area_threshold_nan_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', float('nan')))
+
+    def test_stage_threshold_inf_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('stage_threshold', float('inf')))
+
+    def test_stage_threshold_nan_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('stage_threshold', float('nan')))
+
+    def test_monitoring_frequency_inf_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('monitoring_frequency', float('inf')))
+
     # ---- bool rejection -------------------------------------------------------
 
     def test_area_threshold_bool_true_rejected(self):

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for LoRaRuntimeManager parameter validation and coercion.
+
+Covers _validate_param / _coerce_param / set_parameter boundaries:
+  - min/max inclusive acceptance
+  - out-of-range rejection
+  - fractional rejection for _INT_PARAMS
+  - bool rejection for ranged params
+  - string input coercion
+  - stored-type correctness (int vs float)
+"""
+
+import sys
+import os
+import json
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Ensure tools/ is importable
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', 'tools')
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+# Stub out the LoRa handler dependency so the module can be imported without hardware
+_mock_handler = MagicMock()
+_mock_handler.set_runtime_callback = MagicMock()
+_mock_handler.start_listening = MagicMock()
+
+with patch.dict('sys.modules', {
+    'lora_handler_concurrent': MagicMock(
+        get_lora_handler=MagicMock(return_value=_mock_handler),
+        get_config_value=MagicMock(return_value=None),
+    )
+}):
+    from lora_runtime_integration import LoRaRuntimeManager
+
+
+def _make_manager() -> LoRaRuntimeManager:
+    """Return a manager backed by a temp config file (no LoRa hardware)."""
+    with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+        tmp = f.name
+
+    with patch.object(LoRaRuntimeManager, '_init_lora_handler', lambda self: None):
+        mgr = LoRaRuntimeManager(config_file=tmp)
+    mgr.lora_handler = None
+    return mgr
+
+
+class TestSetParameterRanges(unittest.TestCase):
+
+    def setUp(self):
+        self.mgr = _make_manager()
+
+    # ---- min/max inclusive acceptance ----------------------------------------
+
+    def test_area_threshold_min_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('area_threshold', 0))
+        self.assertEqual(self.mgr.get_parameter('area_threshold'), 0)
+
+    def test_area_threshold_max_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('area_threshold', 100))
+        self.assertEqual(self.mgr.get_parameter('area_threshold'), 100)
+
+    def test_stage_threshold_min_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('stage_threshold', 0))
+
+    def test_stage_threshold_max_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('stage_threshold', 1000))
+
+    def test_monitoring_frequency_min_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('monitoring_frequency', 1))
+
+    def test_monitoring_frequency_max_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('monitoring_frequency', 10080))
+
+    def test_data_retention_days_min_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('data_retention_days', 1))
+
+    def test_data_retention_days_max_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('data_retention_days', 365))
+
+    # ---- out-of-range rejection -----------------------------------------------
+
+    def test_area_threshold_below_min_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', -1))
+
+    def test_area_threshold_above_max_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', 101))
+
+    def test_stage_threshold_above_max_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('stage_threshold', 1001))
+
+    def test_monitoring_frequency_zero_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('monitoring_frequency', 0))
+
+    def test_monitoring_frequency_above_max_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('monitoring_frequency', 10081))
+
+    def test_data_retention_days_above_max_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('data_retention_days', 366))
+
+    # ---- fractional rejection for _INT_PARAMS --------------------------------
+
+    def test_area_threshold_fractional_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', 1.5))
+
+    def test_monitoring_frequency_fractional_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('monitoring_frequency', 60.9))
+
+    def test_photo_interval_fractional_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('photo_interval', 30.1))
+
+    def test_max_retransmissions_fractional_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('max_retransmissions', 3.5))
+
+    def test_shutdown_iteration_limit_fractional_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('shutdown_iteration_limit', 2.9))
+
+    def test_data_retention_days_fractional_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('data_retention_days', 7.7))
+
+    # stage_threshold is NOT in _INT_PARAMS — fractional values should be accepted
+    def test_stage_threshold_fractional_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('stage_threshold', 50.5))
+
+    # ---- bool rejection -------------------------------------------------------
+
+    def test_area_threshold_bool_true_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', True))
+
+    def test_area_threshold_bool_false_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', False))
+
+    def test_monitoring_frequency_bool_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('monitoring_frequency', True))
+
+    def test_stage_threshold_bool_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('stage_threshold', True))
+
+    # Non-ranged params (bool-typed) should still be settable via set_parameter
+    def test_emergency_mode_bool_accepted(self):
+        self.assertTrue(self.mgr.set_parameter('emergency_mode', True))
+        self.assertEqual(self.mgr.get_parameter('emergency_mode'), True)
+
+    # ---- string input coercion -----------------------------------------------
+
+    def test_area_threshold_string_int_coerced(self):
+        self.assertTrue(self.mgr.set_parameter('area_threshold', '50'))
+        self.assertEqual(self.mgr.get_parameter('area_threshold'), 50)
+
+    def test_monitoring_frequency_string_int_coerced(self):
+        self.assertTrue(self.mgr.set_parameter('monitoring_frequency', '60'))
+        self.assertEqual(self.mgr.get_parameter('monitoring_frequency'), 60)
+
+    def test_stage_threshold_string_float_coerced(self):
+        self.assertTrue(self.mgr.set_parameter('stage_threshold', '75'))
+        self.assertEqual(self.mgr.get_parameter('stage_threshold'), 75.0)
+
+    def test_non_numeric_string_rejected(self):
+        self.assertFalse(self.mgr.set_parameter('area_threshold', 'abc'))
+
+    # ---- stored-type correctness ----------------------------------------------
+
+    def test_area_threshold_stored_as_int(self):
+        self.mgr.set_parameter('area_threshold', 30)
+        result = self.mgr.get_parameter('area_threshold')
+        self.assertIsInstance(result, int)
+        self.assertNotIsInstance(result, bool)
+
+    def test_monitoring_frequency_stored_as_int(self):
+        self.mgr.set_parameter('monitoring_frequency', 120)
+        result = self.mgr.get_parameter('monitoring_frequency')
+        self.assertIsInstance(result, int)
+
+    def test_stage_threshold_stored_as_float(self):
+        self.mgr.set_parameter('stage_threshold', 50)
+        result = self.mgr.get_parameter('stage_threshold')
+        self.assertIsInstance(result, float)
+
+    def test_area_threshold_string_stored_as_int(self):
+        self.mgr.set_parameter('area_threshold', '20')
+        result = self.mgr.get_parameter('area_threshold')
+        self.assertIsInstance(result, int)
+        self.assertEqual(result, 20)
+
+    def test_stage_threshold_string_stored_as_float(self):
+        self.mgr.set_parameter('stage_threshold', '100')
+        result = self.mgr.get_parameter('stage_threshold')
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, 100.0)
+
+    # ---- set_parameter return value ------------------------------------------
+
+    def test_set_parameter_returns_bool_true_on_success(self):
+        result = self.mgr.set_parameter('area_threshold', 10)
+        self.assertIs(result, True)
+
+    def test_set_parameter_returns_bool_false_on_rejection(self):
+        result = self.mgr.set_parameter('area_threshold', 999)
+        self.assertIs(result, False)
+
+    # ---- rejected values do not overwrite stored value -----------------------
+
+    def test_rejected_value_does_not_overwrite(self):
+        self.mgr.set_parameter('area_threshold', 20)
+        self.mgr.set_parameter('area_threshold', 999)  # out of range
+        self.assertEqual(self.mgr.get_parameter('area_threshold'), 20)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lora_param_validation.py
+++ b/tests/test_lora_param_validation.py
@@ -17,23 +17,26 @@ import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
 
-# Ensure tools/ is importable
-_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', 'tools')
-if _TOOLS_DIR not in sys.path:
-    sys.path.insert(0, _TOOLS_DIR)
+# Use the repo root so tests import via the same package path as production code
+_REPO_ROOT = os.path.join(os.path.dirname(__file__), '..')
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
-# Stub out the LoRa handler dependency so the module can be imported without hardware
+# Stub out the LoRa handler dependency so the module can be imported without hardware.
+# Patch both bare and package-prefixed names to cover all import strategy fallbacks.
 _mock_handler = MagicMock()
 _mock_handler.set_runtime_callback = MagicMock()
 _mock_handler.start_listening = MagicMock()
+_mock_lora_handler_module = MagicMock(
+    get_lora_handler=MagicMock(return_value=_mock_handler),
+    get_config_value=MagicMock(return_value=None),
+)
 
 with patch.dict('sys.modules', {
-    'lora_handler_concurrent': MagicMock(
-        get_lora_handler=MagicMock(return_value=_mock_handler),
-        get_config_value=MagicMock(return_value=None),
-    )
+    'lora_handler_concurrent': _mock_lora_handler_module,
+    'tools.lora_handler_concurrent': _mock_lora_handler_module,
 }):
-    from lora_runtime_integration import LoRaRuntimeManager
+    from tools.lora_runtime_integration import LoRaRuntimeManager
 
 
 class TestSetParameterRanges(unittest.TestCase):
@@ -67,7 +70,7 @@ class TestSetParameterRanges(unittest.TestCase):
         self.assertTrue(self.mgr.set_parameter('stage_threshold', 0))
 
     def test_stage_threshold_max_accepted(self):
-        self.assertTrue(self.mgr.set_parameter('stage_threshold', 255))
+        self.assertTrue(self.mgr.set_parameter('stage_threshold', 65535))
 
     def test_monitoring_frequency_min_accepted(self):
         self.assertTrue(self.mgr.set_parameter('monitoring_frequency', 1))
@@ -90,7 +93,7 @@ class TestSetParameterRanges(unittest.TestCase):
         self.assertFalse(self.mgr.set_parameter('area_threshold', 101))
 
     def test_stage_threshold_above_max_rejected(self):
-        self.assertFalse(self.mgr.set_parameter('stage_threshold', 256))
+        self.assertFalse(self.mgr.set_parameter('stage_threshold', 65536))
 
     def test_monitoring_frequency_zero_rejected(self):
         self.assertFalse(self.mgr.set_parameter('monitoring_frequency', 0))

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -617,7 +617,7 @@ class LoRaHandler:
                 add_u8(0x09, 0x19, data['status_area_threshold'])
             if 'stage_threshold' in data: 
                 print(f"DEBUG: Processing stage_threshold: {data['stage_threshold']}")
-                add_u8(0x09, 0x29, data['stage_threshold'])
+                add_u8(0x09, 0x29, min(255, int(data['stage_threshold'])))
             if 'monitoring_frequency' in data: 
                 print(f"DEBUG: Processing monitoring_frequency: {data['monitoring_frequency']}")
                 add_u16(0x09, 0x39, data['monitoring_frequency'])

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -617,7 +617,7 @@ class LoRaHandler:
                 add_u8(0x09, 0x19, data['status_area_threshold'])
             if 'stage_threshold' in data: 
                 print(f"DEBUG: Processing stage_threshold: {data['stage_threshold']}")
-                add_u8(0x09, 0x29, min(255, int(data['stage_threshold'])))
+                add_u8(0x09, 0x29, max(0, min(255, int(data['stage_threshold']))))
             if 'monitoring_frequency' in data: 
                 print(f"DEBUG: Processing monitoring_frequency: {data['monitoring_frequency']}")
                 add_u16(0x09, 0x39, data['monitoring_frequency'])

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -106,6 +106,17 @@ class LoRaRuntimeManager:
         'data_retention_days':              (1, 365),
     }
 
+    # Parameters that must be stored as integers (not floats).
+    _INT_PARAMS: frozenset = frozenset({
+        'monitoring_frequency',
+        'emergency_frequency',
+        'photo_interval',
+        'neighborhood_emergency_frequency',
+        'max_retransmissions',
+        'shutdown_iteration_limit',
+        'data_retention_days',
+    })
+
     def __init__(self, config_file='runtime_config.json'):
         self.config_file = config_file
         self.parameters = self.load_parameters()
@@ -224,19 +235,36 @@ class LoRaRuntimeManager:
             return False
         return True
 
+    def _coerce_param(self, key: str, value: Any) -> Any:
+        """Coerce value to the correct type for key (int for integer-only params)."""
+        if key in self._INT_PARAMS:
+            try:
+                return int(float(value))
+            except (TypeError, ValueError):
+                return value
+        return value
+
     def set_parameter(self, key: str, value: Any):
-        """Set a runtime parameter value and save to file"""
+        """Set a runtime parameter value and save to file.
+
+        Validates against _PARAM_RANGES and coerces integer-only params before
+        persisting, so all callers — including the LoRa runtime callback — are
+        protected regardless of how set_parameter() is reached.
+        """
+        if not self._validate_param(key, value):
+            return
+        coerced = self._coerce_param(key, value)
         old_value = self.parameters.get(key)
-        self.parameters[key] = value
+        self.parameters[key] = coerced
         self.save_parameters(self.parameters)
-        
-        print(f"Runtime parameter '{key}' updated: {old_value} → {value}")
-        
+
+        print(f"Runtime parameter '{key}' updated: {old_value} → {coerced}")
+
         # Call any registered update callbacks
         if key in self.update_callbacks:
             for callback in self.update_callbacks[key]:
                 try:
-                    callback(value, old_value)
+                    callback(coerced, old_value)
                 except Exception as e:
                     print(f"Error in parameter update callback for '{key}': {e}")
     
@@ -333,52 +361,59 @@ class LoRaRuntimeManager:
                     return 0
                 return int.from_bytes(b, byteorder='big', signed=False)
 
-            def _apply_command_tlv(ch: int, cmd: int, value_bytes: bytes):
+            def _apply_command_tlv(ch: int, cmd: int, value_bytes: bytes) -> bool:
                 channel = f"{ch:02d}"
                 command = f"{cmd:02d}"
                 val_int = _to_int_be(value_bytes)
 
-                def _set(param, value):
-                    if self._validate_param(param, value):
-                        self.set_parameter(param, value)
+                def _set(param, value) -> bool:
+                    if not self._validate_param(param, value):
+                        return False
+                    self.set_parameter(param, value)
+                    return True
 
                 if channel == '10' and command == '90':
-                    _set('area_threshold', val_int * 10)
+                    return _set('area_threshold', val_int * 10)
                 elif channel == '11' and command == '91':
-                    _set('stage_threshold', float(val_int))
+                    return _set('stage_threshold', float(val_int))
                 elif channel == '12' and command == '92':
-                    _set('monitoring_frequency', val_int)
+                    return _set('monitoring_frequency', val_int)
                 elif channel == '13' and command == '93':
-                    _set('emergency_frequency', val_int)
+                    return _set('emergency_frequency', val_int)
                 elif channel == '14' and command == '94':
-                    _set('photo_interval', val_int)
+                    return _set('photo_interval', val_int)
                 elif channel == '15' and command == '95':
-                    _set('neighborhood_emergency_frequency', val_int)
+                    return _set('neighborhood_emergency_frequency', val_int)
                 elif channel == '22' and command == '00':
                     self.set_parameter('debug_mode', bool(val_int))
+                    return True
                 elif channel == '31' and command == '00':
-                    pass
+                    return True
                 elif channel == '32' and command == '00':
-                    _set('max_retransmissions', val_int)
+                    return _set('max_retransmissions', val_int)
                 elif channel == '40' and command == '00':
                     self.set_parameter('auto_shutdown_enabled', bool(val_int))
+                    return True
                 elif channel == '41' and command == '00':
-                    _set('shutdown_iteration_limit', val_int)
+                    return _set('shutdown_iteration_limit', val_int)
                 elif channel == '42' and command == '00':
-                    _set('data_retention_days', val_int)
+                    return _set('data_retention_days', val_int)
                 elif channel == '43' and command == '00':
                     self.set_parameter('backup_enabled', bool(val_int))
+                    return True
                 elif channel == '21' and command == '00':
                     self.set_parameter('emergency_mode', True)
+                    return True
                 elif channel == '99' and command == '00':
                     self.set_parameter('emergency_mode', False)
+                    return True
+                return True
 
             if _is_hex_string(payload):
                 tlv_cmds = _parse_tlv_commands(payload)
                 if tlv_cmds is not None and len(tlv_cmds) > 0:
-                    for (ch, cmd, vbytes) in tlv_cmds:
-                        _apply_command_tlv(ch, cmd, vbytes)
-                    return True
+                    all_ok = all(_apply_command_tlv(ch, cmd, vbytes) for (ch, cmd, vbytes) in tlv_cmds)
+                    return all_ok
 
             # Handle new format: [Channel][Command][Value] (single)
             if len(payload) >= 4:

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -143,11 +143,11 @@ class LoRaRuntimeManager:
                 """Sync LoRa parameter updates with runtime parameters"""
                 print(f"🔄 LoRa parameter update: {key} = {value}")
                 print(f"   Current runtime value: {self.get_parameter(key)}")
-                
-                # Update the runtime parameter directly
-                self.set_parameter(key, value)
-                print(f"✅ Runtime parameter '{key}' synced to {value}")
-                print(f"   New runtime value: {self.get_parameter(key)}")
+                if self.set_parameter(key, value):
+                    print(f"✅ Runtime parameter '{key}' synced to {value}")
+                    print(f"   New runtime value: {self.get_parameter(key)}")
+                else:
+                    print(f"⚠️ Runtime parameter '{key}' rejected value {value!r} (out of range or invalid)")
             
             print(f"🔧 Attempting to set runtime callback...")
             self.lora_handler.set_runtime_callback(sync_lora_command)
@@ -524,19 +524,21 @@ class LoRaRuntimeManager:
             # Get current LoRa config
             lora_config = self.lora_handler.config
             
-            # Update runtime parameters with any new values from LoRa
+            # Update runtime parameters with any new values from LoRa.
+            # Route through set_parameter() so validation/coercion is applied.
             changes = []
             for key, value in lora_config.items():
                 if key in self.parameters and self.parameters[key] != value:
                     old_value = self.parameters[key]
-                    self.parameters[key] = value
-                    changes.append(f"{key}: {old_value} → {value}")
-            
+                    if self.set_parameter(key, value):
+                        changes.append(f"{key}: {old_value} → {value}")
+                    else:
+                        print(f"  Warning: skipped out-of-range value for '{key}': {value!r}")
+
             if changes:
                 print(f"🔄 Synced {len(changes)} parameters from LoRa config:")
                 for change in changes:
                     print(f"  {change}")
-                self.save_parameters(self.parameters)
                 return True
             else:
                 print("✓ Runtime parameters already in sync with LoRa config")
@@ -593,10 +595,10 @@ def get_parameter(key: str, default: Any = None) -> Any:
     manager = get_runtime_manager()
     return manager.get_parameter(key, default)
 
-def set_parameter(key: str, value: Any):
+def set_parameter(key: str, value: Any) -> bool:
     """Convenience function to set a runtime parameter"""
     manager = get_runtime_manager()
-    manager.set_parameter(key, value)
+    return manager.set_parameter(key, value)
 
 def register_callback(parameter: str, callback: Callable):
     """Convenience function to register a parameter update callback"""

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -224,11 +224,19 @@ class LoRaRuntimeManager:
         bounds = self._PARAM_RANGES.get(key)
         if bounds is None:
             return True
+        # Reject booleans — bool subclasses int but is semantically wrong for numeric params
+        if isinstance(value, bool):
+            print(f"Warning: boolean value {value!r} for parameter '{key}', rejected")
+            return False
         lo, hi = bounds
         try:
             numeric = float(value)
         except (TypeError, ValueError):
             print(f"Warning: non-numeric value {value!r} for parameter '{key}', rejected")
+            return False
+        # Reject fractional values for integer-only params (e.g. 1.9 must not silently become 1)
+        if key in self._INT_PARAMS and numeric != int(numeric):
+            print(f"Warning: fractional value {value} for integer parameter '{key}', rejected")
             return False
         if not (lo <= numeric <= hi):
             print(f"Warning: value {value} for '{key}' is outside allowed range [{lo}, {hi}], rejected")
@@ -236,23 +244,26 @@ class LoRaRuntimeManager:
         return True
 
     def _coerce_param(self, key: str, value: Any) -> Any:
-        """Coerce value to the correct type for key (int for integer-only params)."""
+        """Coerce value to the correct stored type for key.
+
+        Safe to call only after _validate_param() has already accepted the value —
+        at that point booleans and fractional inputs have been rejected, so
+        int(float(value)) is exact.
+        """
         if key in self._INT_PARAMS:
-            try:
-                return int(float(value))
-            except (TypeError, ValueError):
-                return value
+            return int(float(value))
         return value
 
-    def set_parameter(self, key: str, value: Any):
+    def set_parameter(self, key: str, value: Any) -> bool:
         """Set a runtime parameter value and save to file.
 
         Validates against _PARAM_RANGES and coerces integer-only params before
-        persisting, so all callers — including the LoRa runtime callback — are
-        protected regardless of how set_parameter() is reached.
+        persisting. Returns True if the value was applied, False if rejected.
+        All callers — including the LoRa runtime callback — are protected
+        regardless of how set_parameter() is reached.
         """
         if not self._validate_param(key, value):
-            return
+            return False
         coerced = self._coerce_param(key, value)
         old_value = self.parameters.get(key)
         self.parameters[key] = coerced
@@ -260,13 +271,13 @@ class LoRaRuntimeManager:
 
         print(f"Runtime parameter '{key}' updated: {old_value} → {coerced}")
 
-        # Call any registered update callbacks
         if key in self.update_callbacks:
             for callback in self.update_callbacks[key]:
                 try:
                     callback(coerced, old_value)
                 except Exception as e:
                     print(f"Error in parameter update callback for '{key}': {e}")
+        return True
     
     def register_update_callback(self, parameter: str, callback: Callable):
         """Register a callback to be called when a parameter is updated"""
@@ -367,10 +378,7 @@ class LoRaRuntimeManager:
                 val_int = _to_int_be(value_bytes)
 
                 def _set(param, value) -> bool:
-                    if not self._validate_param(param, value):
-                        return False
-                    self.set_parameter(param, value)
-                    return True
+                    return self.set_parameter(param, value)
 
                 if channel == '10' and command == '90':
                     return _set('area_threshold', val_int * 10)
@@ -423,174 +431,45 @@ class LoRaRuntimeManager:
                 
                 print(f"DEBUG: Parsed - Channel: {channel}, Command: {command}, Value: {value}")
                 
-                # Process commands based on channel and command combination
-                if channel == '10' and command == '90':
-                    # Area threshold - value represents 10% increments
-                    try:
-                        val = int(value) * 10
-                        if not self._validate_param('area_threshold', val):
-                            return False
-                        self.set_parameter('area_threshold', val)
-                        return True
-                    except ValueError as e:
-                        print(f'Invalid area threshold value: {value}, error: {e}')
+                # Process commands based on channel and command combination.
+                # set_parameter() is the single validation + coercion point; dispatchers
+                # just parse the raw string into the right type and delegate.
+                try:
+                    if channel == '10' and command == '90':
+                        return self.set_parameter('area_threshold', int(value) * 10)
+                    elif channel == '11' and command == '91':
+                        return self.set_parameter('stage_threshold', float(value))
+                    elif channel == '12' and command == '92':
+                        return self.set_parameter('monitoring_frequency', int(value))
+                    elif channel == '13' and command == '93':
+                        return self.set_parameter('emergency_frequency', int(value))
+                    elif channel == '14' and command == '94':
+                        return self.set_parameter('photo_interval', int(value))
+                    elif channel == '15' and command == '95':
+                        return self.set_parameter('neighborhood_emergency_frequency', int(value))
+                    elif channel == '22' and command == '00':
+                        return self.set_parameter('debug_mode', bool(int(value)))
+                    elif channel == '31' and command == '00':
+                        return self.set_parameter('compression_level', max(1, min(10, int(value))))
+                    elif channel == '32' and command == '00':
+                        return self.set_parameter('max_retransmissions', int(value))
+                    elif channel == '40' and command == '00':
+                        return self.set_parameter('auto_shutdown_enabled', bool(int(value)))
+                    elif channel == '41' and command == '00':
+                        return self.set_parameter('shutdown_iteration_limit', int(value))
+                    elif channel == '42' and command == '00':
+                        return self.set_parameter('data_retention_days', int(value))
+                    elif channel == '43' and command == '00':
+                        return self.set_parameter('backup_enabled', bool(int(value)))
+                    elif channel == '21' and command == '00':
+                        return self.set_parameter('emergency_mode', True)
+                    elif channel == '99' and command == '00':
+                        return self.set_parameter('emergency_mode', False)
+                    else:
+                        print(f'Unknown channel/command combination: Channel {channel}, Command {command} with value: {value}')
                         return False
-
-                elif channel == '11' and command == '91':
-                    # Stage threshold - continuous cm value
-                    try:
-                        val = float(value)
-                        if not self._validate_param('stage_threshold', val):
-                            return False
-                        self.set_parameter('stage_threshold', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid stage threshold value: {value}')
-                        return False
-
-                elif channel == '12' and command == '92':
-                    # Monitoring frequency - minute value
-                    try:
-                        val = int(value)
-                        if not self._validate_param('monitoring_frequency', val):
-                            return False
-                        self.set_parameter('monitoring_frequency', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid monitoring frequency value: {value}')
-                        return False
-
-                elif channel == '13' and command == '93':
-                    # Emergency frequency - minute value
-                    try:
-                        val = int(value)
-                        if not self._validate_param('emergency_frequency', val):
-                            return False
-                        self.set_parameter('emergency_frequency', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid emergency frequency value: {value}')
-                        return False
-
-                elif channel == '14' and command == '94':
-                    # Photo interval - minute value
-                    try:
-                        val = int(value)
-                        if not self._validate_param('photo_interval', val):
-                            return False
-                        self.set_parameter('photo_interval', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid photo interval value: {value}')
-                        return False
-
-                elif channel == '15' and command == '95':
-                    # Neighborhood emergency frequency - minute value
-                    try:
-                        val = int(value)
-                        if not self._validate_param('neighborhood_emergency_frequency', val):
-                            return False
-                        self.set_parameter('neighborhood_emergency_frequency', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid neighborhood emergency frequency value: {value}')
-                        return False
-                        
-                # Removed: transmission enable/disable command (always-on policy)
-                        
-                elif channel == '22' and command == '00':
-                    # Debug mode
-                    try:
-                        val = bool(int(value))
-                        self.set_parameter('debug_mode', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid debug mode value: {value}')
-                        return False
-                        
-                # Removed: GPS enable/disable command (not supported)
-                        
-                # Removed: battery threshold command (not supported)
-                        
-                elif channel == '31' and command == '00':
-                    # Compression level
-                    try:
-                        val = int(value)
-                        val = max(1, min(10, val))  # Clamp between 1-10
-                        self.set_parameter('compression_level', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid compression level value: {value}')
-                        return False
-                        
-                elif channel == '32' and command == '00':
-                    # Max retransmissions
-                    try:
-                        val = int(value)
-                        if not self._validate_param('max_retransmissions', val):
-                            return False
-                        self.set_parameter('max_retransmissions', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid max retransmissions value: {value}')
-                        return False
-
-                elif channel == '40' and command == '00':
-                    # Auto shutdown enabled/disabled
-                    try:
-                        val = bool(int(value))
-                        self.set_parameter('auto_shutdown_enabled', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid auto shutdown value: {value}')
-                        return False
-
-                elif channel == '41' and command == '00':
-                    # Shutdown iteration limit
-                    try:
-                        val = int(value)
-                        if not self._validate_param('shutdown_iteration_limit', val):
-                            return False
-                        self.set_parameter('shutdown_iteration_limit', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid shutdown iteration limit value: {value}')
-                        return False
-
-                elif channel == '42' and command == '00':
-                    # Data retention days
-                    try:
-                        val = int(value)
-                        if not self._validate_param('data_retention_days', val):
-                            return False
-                        self.set_parameter('data_retention_days', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid data retention value: {value}')
-                        return False
-                        
-                elif channel == '43' and command == '00':
-                    # Backup enabled/disabled
-                    try:
-                        val = bool(int(value))
-                        self.set_parameter('backup_enabled', val)
-                        return True
-                    except ValueError:
-                        print(f'Invalid backup value: {value}')
-                        return False
-                        
-                elif channel == '21' and command == '00':
-                    # Emergency status: system enters emergency mode and stops scheduled shutdowns
-                    self.set_parameter('emergency_mode', True)
-                    return True
-                    
-                elif channel == '99' and command == '00':
-                    # Deactivate emergency mode
-                    self.set_parameter('emergency_mode', False)
-                    return True
-                    
-                else:
-                    print(f'Unknown channel/command combination: Channel {channel}, Command {command} with value: {value}')
+                except (ValueError, TypeError) as e:
+                    print(f'Invalid value for channel {channel} command {command}: {value!r} ({e})')
                     return False
             else:
                 print(f'Invalid payload format: {payload} (minimum 4 characters required for [Channel][Command][Value] format)')

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -91,7 +91,21 @@ class LoRaRuntimeManager:
     Manages runtime parameters that can be updated via LoRa commands
     and integrates with the ticktalk_main.py system
     """
-    
+
+    # Inclusive (min, max) bounds for each settable parameter.
+    # Values outside these ranges are rejected with a warning.
+    _PARAM_RANGES: dict = {
+        'area_threshold':                   (0, 100),
+        'stage_threshold':                  (0, 1000),
+        'monitoring_frequency':             (1, 10080),
+        'emergency_frequency':              (1, 1440),
+        'photo_interval':                   (1, 1440),
+        'neighborhood_emergency_frequency': (1, 1440),
+        'max_retransmissions':              (0, 10),
+        'shutdown_iteration_limit':         (1, 100),
+        'data_retention_days':              (1, 365),
+    }
+
     def __init__(self, config_file='runtime_config.json'):
         self.config_file = config_file
         self.parameters = self.load_parameters()
@@ -194,6 +208,22 @@ class LoRaRuntimeManager:
         """Check if LoRa functionality is available"""
         return self.lora_handler is not None
     
+    def _validate_param(self, key: str, value: Any) -> bool:
+        """Return True if value is within the allowed range for key, False otherwise."""
+        bounds = self._PARAM_RANGES.get(key)
+        if bounds is None:
+            return True
+        lo, hi = bounds
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            print(f"Warning: non-numeric value {value!r} for parameter '{key}', rejected")
+            return False
+        if not (lo <= numeric <= hi):
+            print(f"Warning: value {value} for '{key}' is outside allowed range [{lo}, {hi}], rejected")
+            return False
+        return True
+
     def set_parameter(self, key: str, value: Any):
         """Set a runtime parameter value and save to file"""
         old_value = self.parameters.get(key)
@@ -307,30 +337,35 @@ class LoRaRuntimeManager:
                 channel = f"{ch:02d}"
                 command = f"{cmd:02d}"
                 val_int = _to_int_be(value_bytes)
+
+                def _set(param, value):
+                    if self._validate_param(param, value):
+                        self.set_parameter(param, value)
+
                 if channel == '10' and command == '90':
-                    self.set_parameter('area_threshold', val_int * 10)
+                    _set('area_threshold', val_int * 10)
                 elif channel == '11' and command == '91':
-                    self.set_parameter('stage_threshold', float(val_int))
+                    _set('stage_threshold', float(val_int))
                 elif channel == '12' and command == '92':
-                    self.set_parameter('monitoring_frequency', val_int)
+                    _set('monitoring_frequency', val_int)
                 elif channel == '13' and command == '93':
-                    self.set_parameter('emergency_frequency', val_int)
+                    _set('emergency_frequency', val_int)
                 elif channel == '14' and command == '94':
-                    self.set_parameter('photo_interval', val_int)
+                    _set('photo_interval', val_int)
                 elif channel == '15' and command == '95':
-                    self.set_parameter('neighborhood_emergency_frequency', val_int)
+                    _set('neighborhood_emergency_frequency', val_int)
                 elif channel == '22' and command == '00':
                     self.set_parameter('debug_mode', bool(val_int))
                 elif channel == '31' and command == '00':
                     pass
                 elif channel == '32' and command == '00':
-                    self.set_parameter('max_retransmissions', val_int)
+                    _set('max_retransmissions', val_int)
                 elif channel == '40' and command == '00':
                     self.set_parameter('auto_shutdown_enabled', bool(val_int))
                 elif channel == '41' and command == '00':
-                    self.set_parameter('shutdown_iteration_limit', val_int)
+                    _set('shutdown_iteration_limit', val_int)
                 elif channel == '42' and command == '00':
-                    self.set_parameter('data_retention_days', val_int)
+                    _set('data_retention_days', val_int)
                 elif channel == '43' and command == '00':
                     self.set_parameter('backup_enabled', bool(val_int))
                 elif channel == '21' and command == '00':
@@ -358,56 +393,68 @@ class LoRaRuntimeManager:
                     # Area threshold - value represents 10% increments
                     try:
                         val = int(value) * 10
+                        if not self._validate_param('area_threshold', val):
+                            return False
                         self.set_parameter('area_threshold', val)
                         return True
                     except ValueError as e:
                         print(f'Invalid area threshold value: {value}, error: {e}')
                         return False
-                        
+
                 elif channel == '11' and command == '91':
                     # Stage threshold - continuous cm value
                     try:
                         val = float(value)
+                        if not self._validate_param('stage_threshold', val):
+                            return False
                         self.set_parameter('stage_threshold', val)
                         return True
                     except ValueError:
                         print(f'Invalid stage threshold value: {value}')
                         return False
-                        
+
                 elif channel == '12' and command == '92':
                     # Monitoring frequency - minute value
                     try:
                         val = int(value)
+                        if not self._validate_param('monitoring_frequency', val):
+                            return False
                         self.set_parameter('monitoring_frequency', val)
                         return True
                     except ValueError:
                         print(f'Invalid monitoring frequency value: {value}')
                         return False
-                        
+
                 elif channel == '13' and command == '93':
                     # Emergency frequency - minute value
                     try:
                         val = int(value)
+                        if not self._validate_param('emergency_frequency', val):
+                            return False
                         self.set_parameter('emergency_frequency', val)
                         return True
                     except ValueError:
                         print(f'Invalid emergency frequency value: {value}')
                         return False
-                        
+
                 elif channel == '14' and command == '94':
                     # Photo interval - minute value
                     try:
                         val = int(value)
+                        if not self._validate_param('photo_interval', val):
+                            return False
                         self.set_parameter('photo_interval', val)
                         return True
                     except ValueError:
                         print(f'Invalid photo interval value: {value}')
                         return False
-                        
+
                 elif channel == '15' and command == '95':
                     # Neighborhood emergency frequency - minute value
                     try:
                         val = int(value)
+                        if not self._validate_param('neighborhood_emergency_frequency', val):
+                            return False
                         self.set_parameter('neighborhood_emergency_frequency', val)
                         return True
                     except ValueError:
@@ -445,12 +492,14 @@ class LoRaRuntimeManager:
                     # Max retransmissions
                     try:
                         val = int(value)
+                        if not self._validate_param('max_retransmissions', val):
+                            return False
                         self.set_parameter('max_retransmissions', val)
                         return True
                     except ValueError:
                         print(f'Invalid max retransmissions value: {value}')
                         return False
-                        
+
                 elif channel == '40' and command == '00':
                     # Auto shutdown enabled/disabled
                     try:
@@ -460,21 +509,25 @@ class LoRaRuntimeManager:
                     except ValueError:
                         print(f'Invalid auto shutdown value: {value}')
                         return False
-                        
+
                 elif channel == '41' and command == '00':
                     # Shutdown iteration limit
                     try:
                         val = int(value)
+                        if not self._validate_param('shutdown_iteration_limit', val):
+                            return False
                         self.set_parameter('shutdown_iteration_limit', val)
                         return True
                     except ValueError:
                         print(f'Invalid shutdown iteration limit value: {value}')
                         return False
-                        
+
                 elif channel == '42' and command == '00':
                     # Data retention days
                     try:
                         val = int(value)
+                        if not self._validate_param('data_retention_days', val):
+                            return False
                         self.set_parameter('data_retention_days', val)
                         return True
                     except ValueError:

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -281,9 +281,10 @@ class LoRaRuntimeManager:
         coerced = self._coerce_param(key, value)
         old_value = self.parameters.get(key)
         self.parameters[key] = coerced
-        saved = self.save_parameters(self.parameters)
-        if not saved:
-            print(f"Warning: parameter '{key}' updated in memory but failed to persist to disk")
+        if not self.save_parameters(self.parameters):
+            self.parameters[key] = old_value
+            print(f"Warning: failed to persist '{key}', change rolled back")
+            return False
 
         print(f"Runtime parameter '{key}' updated: {old_value} → {coerced}")
 
@@ -293,7 +294,7 @@ class LoRaRuntimeManager:
                     callback(coerced, old_value)
                 except Exception as e:
                     print(f"Error in parameter update callback for '{key}': {e}")
-        return saved
+        return True
     
     def register_update_callback(self, parameter: str, callback: Callable):
         """Register a callback to be called when a parameter is updated"""
@@ -404,28 +405,23 @@ class LoRaRuntimeManager:
                 elif channel == '15' and command == '95':
                     return _set('neighborhood_emergency_frequency', val_int)
                 elif channel == '22' and command == '00':
-                    self.set_parameter('debug_mode', bool(val_int))
-                    return True
+                    return _set('debug_mode', bool(val_int))
                 elif channel == '31' and command == '00':
                     return _set('compression_level', val_int)
                 elif channel == '32' and command == '00':
                     return _set('max_retransmissions', val_int)
                 elif channel == '40' and command == '00':
-                    self.set_parameter('auto_shutdown_enabled', bool(val_int))
-                    return True
+                    return _set('auto_shutdown_enabled', bool(val_int))
                 elif channel == '41' and command == '00':
                     return _set('shutdown_iteration_limit', val_int)
                 elif channel == '42' and command == '00':
                     return _set('data_retention_days', val_int)
                 elif channel == '43' and command == '00':
-                    self.set_parameter('backup_enabled', bool(val_int))
-                    return True
+                    return _set('backup_enabled', bool(val_int))
                 elif channel == '21' and command == '00':
-                    self.set_parameter('emergency_mode', True)
-                    return True
+                    return _set('emergency_mode', True)
                 elif channel == '99' and command == '00':
-                    self.set_parameter('emergency_mode', False)
-                    return True
+                    return _set('emergency_mode', False)
                 else:
                     print(f"Warning: unknown TLV channel/command {channel}/{command}, ignored")
                     return False
@@ -544,7 +540,9 @@ class LoRaRuntimeManager:
                         print(f"  Warning: skipped out-of-range value for '{key}': {value!r}")
 
             if changes:
-                self.save_parameters(self.parameters)
+                if not self.save_parameters(self.parameters):
+                    print(f"Warning: failed to persist {len(changes)} synced parameter(s) to disk")
+                    return False
                 print(f"🔄 Synced {len(changes)} parameters from LoRa config:")
                 for change in changes:
                     print(f"  {change}")

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -97,7 +97,7 @@ class LoRaRuntimeManager:
     # Values outside these ranges are rejected with a warning.
     _PARAM_RANGES: dict = {
         'area_threshold':                   (0, 100),
-        'stage_threshold':                  (0, 255),
+        'stage_threshold':                  (0, 65535),
         'monitoring_frequency':             (1, 10080),
         'emergency_frequency':              (1, 1440),
         'photo_interval':                   (1, 1440),
@@ -401,7 +401,7 @@ class LoRaRuntimeManager:
                     self.set_parameter('debug_mode', bool(val_int))
                     return True
                 elif channel == '31' and command == '00':
-                    return True
+                    return _set('compression_level', max(1, min(10, val_int)))
                 elif channel == '32' and command == '00':
                     return _set('max_retransmissions', val_int)
                 elif channel == '40' and command == '00':

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -19,6 +19,7 @@ Usage:
 """
 
 import json
+import math
 import os
 import time
 import threading
@@ -235,6 +236,10 @@ class LoRaRuntimeManager:
         except (TypeError, ValueError):
             print(f"Warning: non-numeric value {value!r} for parameter '{key}', rejected")
             return False
+        # Reject non-finite values (inf/nan pass float() but crash int() with OverflowError/ValueError)
+        if not math.isfinite(numeric):
+            print(f"Warning: non-finite value {value!r} for parameter '{key}', rejected")
+            return False
         # Reject fractional values for integer-only params (e.g. 1.9 must not silently become 1)
         if key in self._INT_PARAMS and numeric != int(numeric):
             print(f"Warning: fractional value {value} for integer parameter '{key}', rejected")
@@ -288,10 +293,6 @@ class LoRaRuntimeManager:
         if parameter not in self.update_callbacks:
             self.update_callbacks[parameter] = []
         self.update_callbacks[parameter].append(callback)
-    
-    def process_lora_payload(self, payload: str) -> bool:
-        """Process LoRa payload directly from the handler (alias for process_lora_command)"""
-        return self.process_lora_command(payload)
     
     def process_lora_command(self, command: str, value: Any) -> bool:
         """Process incoming LoRa command in old format (backward compatibility)"""
@@ -425,13 +426,22 @@ class LoRaRuntimeManager:
             if _is_hex_string(payload):
                 tlv_cmds = _parse_tlv_commands(payload)
                 if tlv_cmds is not None and len(tlv_cmds) > 0:
-                    results = [_apply_command_tlv(ch, cmd, vbytes) for (ch, cmd, vbytes) in tlv_cmds]
-                    # All-or-nothing: any rejected/unknown command returns False so the
-                    # sender knows the packet was not fully applied.
-                    if not all(results):
-                        failed = [f"{ch:02d}/{cmd:02d}" for (ch, cmd, _), ok in zip(tlv_cmds, results) if not ok]
-                        print(f"Warning: {len(failed)}/{len(results)} TLV commands not applied: {failed}")
-                    return all(results)
+                    results = []
+                    failed = []
+                    for ch, cmd, vbytes in tlv_cmds:
+                        ok = _apply_command_tlv(ch, cmd, vbytes)
+                        results.append(ok)
+                        if not ok:
+                            failed.append(f"{ch:02d}/{cmd:02d}")
+                    # Commands applied sequentially — partial apply is possible:
+                    # if a later command fails, earlier successful ones remain persisted.
+                    fully_applied = all(results)
+                    if not fully_applied:
+                        print(
+                            f"Warning: {len(failed)}/{len(results)} TLV commands not applied: {failed}. "
+                            "Earlier commands in the same payload may already have been applied."
+                        )
+                    return fully_applied
 
             # Handle new format: [Channel][Command][Value] (single)
             if len(payload) >= 4:

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -325,8 +325,7 @@ class LoRaRuntimeManager:
         
         if command in command_mapping:
             try:
-                command_mapping[command](value)
-                return True
+                return bool(command_mapping[command](value))
             except Exception as e:
                 print(f"Error processing LoRa command '{command}' with value '{value}': {e}")
                 return False
@@ -427,6 +426,11 @@ class LoRaRuntimeManager:
                 tlv_cmds = _parse_tlv_commands(payload)
                 if tlv_cmds is not None and len(tlv_cmds) > 0:
                     results = [_apply_command_tlv(ch, cmd, vbytes) for (ch, cmd, vbytes) in tlv_cmds]
+                    # All-or-nothing: any rejected/unknown command returns False so the
+                    # sender knows the packet was not fully applied.
+                    if not all(results):
+                        failed = [f"{ch:02d}/{cmd:02d}" for (ch, cmd, _), ok in zip(tlv_cmds, results) if not ok]
+                        print(f"Warning: {len(failed)}/{len(results)} TLV commands not applied: {failed}")
                     return all(results)
 
             # Handle new format: [Channel][Command][Value] (single)

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -108,6 +108,7 @@ class LoRaRuntimeManager:
 
     # Parameters that must be stored as integers (not floats).
     _INT_PARAMS: frozenset = frozenset({
+        'area_threshold',
         'monitoring_frequency',
         'emergency_frequency',
         'photo_interval',
@@ -246,12 +247,15 @@ class LoRaRuntimeManager:
     def _coerce_param(self, key: str, value: Any) -> Any:
         """Coerce value to the correct stored type for key.
 
-        Safe to call only after _validate_param() has already accepted the value —
-        at that point booleans and fractional inputs have been rejected, so
-        int(float(value)) is exact.
+        Safe to call only after _validate_param() has already accepted the value.
+        Integer-only ranged params are stored as int; other ranged numeric params
+        are stored as float so the persisted config is type-consistent even when
+        callers supply string inputs such as "50" or "0.75".
         """
         if key in self._INT_PARAMS:
             return int(float(value))
+        if key in self._PARAM_RANGES:
+            return float(value)
         return value
 
     def set_parameter(self, key: str, value: Any) -> bool:
@@ -415,13 +419,15 @@ class LoRaRuntimeManager:
                 elif channel == '99' and command == '00':
                     self.set_parameter('emergency_mode', False)
                     return True
-                return True
+                else:
+                    print(f"Warning: unknown TLV channel/command {channel}/{command}, ignored")
+                    return False
 
             if _is_hex_string(payload):
                 tlv_cmds = _parse_tlv_commands(payload)
                 if tlv_cmds is not None and len(tlv_cmds) > 0:
-                    all_ok = all(_apply_command_tlv(ch, cmd, vbytes) for (ch, cmd, vbytes) in tlv_cmds)
-                    return all_ok
+                    results = [_apply_command_tlv(ch, cmd, vbytes) for (ch, cmd, vbytes) in tlv_cmds]
+                    return all(results)
 
             # Handle new format: [Channel][Command][Value] (single)
             if len(payload) >= 4:

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -524,18 +524,21 @@ class LoRaRuntimeManager:
             # Get current LoRa config
             lora_config = self.lora_handler.config
             
-            # Update runtime parameters with any new values from LoRa.
-            # Route through set_parameter() so validation/coercion is applied.
+            # Validate/coerce all changes in-memory first, then persist once.
+            # Avoids one save_parameters() call per changed key on constrained hardware.
             changes = []
             for key, value in lora_config.items():
                 if key in self.parameters and self.parameters[key] != value:
                     old_value = self.parameters[key]
-                    if self.set_parameter(key, value):
-                        changes.append(f"{key}: {old_value} → {value}")
+                    if self._validate_param(key, value):
+                        coerced = self._coerce_param(key, value)
+                        self.parameters[key] = coerced
+                        changes.append(f"{key}: {old_value} → {coerced}")
                     else:
                         print(f"  Warning: skipped out-of-range value for '{key}': {value!r}")
 
             if changes:
+                self.save_parameters(self.parameters)
                 print(f"🔄 Synced {len(changes)} parameters from LoRa config:")
                 for change in changes:
                     print(f"  {change}")

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -207,13 +207,15 @@ class LoRaRuntimeManager:
             self.save_parameters(default_params)
             return default_params
     
-    def save_parameters(self, params: Dict[str, Any]):
-        """Save runtime parameters to file"""
+    def save_parameters(self, params: Dict[str, Any]) -> bool:
+        """Save runtime parameters to file. Returns True on success, False on failure."""
         try:
             with open(self.config_file, 'w') as f:
                 json.dump(params, f, indent=2)
+            return True
         except Exception as e:
             print(f"Error saving runtime config: {e}")
+            return False
     
     def get_parameter(self, key: str, default: Any = None) -> Any:
         """Get a runtime parameter value"""
@@ -235,7 +237,7 @@ class LoRaRuntimeManager:
         lo, hi = bounds
         try:
             numeric = float(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             print(f"Warning: non-numeric value {value!r} for parameter '{key}', rejected")
             return False
         # Reject non-finite values (inf/nan pass float() but crash int() with OverflowError/ValueError)
@@ -279,7 +281,9 @@ class LoRaRuntimeManager:
         coerced = self._coerce_param(key, value)
         old_value = self.parameters.get(key)
         self.parameters[key] = coerced
-        self.save_parameters(self.parameters)
+        saved = self.save_parameters(self.parameters)
+        if not saved:
+            print(f"Warning: parameter '{key}' updated in memory but failed to persist to disk")
 
         print(f"Runtime parameter '{key}' updated: {old_value} → {coerced}")
 
@@ -289,7 +293,7 @@ class LoRaRuntimeManager:
                     callback(coerced, old_value)
                 except Exception as e:
                     print(f"Error in parameter update callback for '{key}': {e}")
-        return True
+        return saved
     
     def register_update_callback(self, parameter: str, callback: Callable):
         """Register a callback to be called when a parameter is updated"""
@@ -403,7 +407,7 @@ class LoRaRuntimeManager:
                     self.set_parameter('debug_mode', bool(val_int))
                     return True
                 elif channel == '31' and command == '00':
-                    return _set('compression_level', max(1, min(10, val_int)))
+                    return _set('compression_level', val_int)
                 elif channel == '32' and command == '00':
                     return _set('max_retransmissions', val_int)
                 elif channel == '40' and command == '00':
@@ -473,7 +477,7 @@ class LoRaRuntimeManager:
                     elif channel == '22' and command == '00':
                         return self.set_parameter('debug_mode', bool(int(value)))
                     elif channel == '31' and command == '00':
-                        return self.set_parameter('compression_level', max(1, min(10, int(value))))
+                        return self.set_parameter('compression_level', int(value))
                     elif channel == '32' and command == '00':
                         return self.set_parameter('max_retransmissions', int(value))
                     elif channel == '40' and command == '00':

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -105,6 +105,7 @@ class LoRaRuntimeManager:
         'max_retransmissions':              (0, 10),
         'shutdown_iteration_limit':         (1, 100),
         'data_retention_days':              (1, 365),
+        'compression_level':               (1, 10),
     }
 
     # Parameters that must be stored as integers (not floats).
@@ -117,6 +118,7 @@ class LoRaRuntimeManager:
         'max_retransmissions',
         'shutdown_iteration_limit',
         'data_retention_days',
+        'compression_level',
     })
 
     def __init__(self, config_file='runtime_config.json'):

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -105,7 +105,7 @@ class LoRaRuntimeManager:
         'max_retransmissions':              (0, 10),
         'shutdown_iteration_limit':         (1, 100),
         'data_retention_days':              (1, 365),
-        'compression_level':               (1, 10),
+        'compression_level':                (1, 10),
     }
 
     # Parameters that must be stored as integers (not floats).
@@ -281,6 +281,7 @@ class LoRaRuntimeManager:
         coerced = self._coerce_param(key, value)
         _MISSING = object()
         old_value = self.parameters.get(key, _MISSING)
+        prior = None if old_value is _MISSING else old_value
         self.parameters[key] = coerced
         if not self.save_parameters(self.parameters):
             if old_value is _MISSING:
@@ -290,12 +291,12 @@ class LoRaRuntimeManager:
             print(f"Warning: failed to persist '{key}', change rolled back")
             return False
 
-        print(f"Runtime parameter '{key}' updated: {old_value} → {coerced}")
+        print(f"Runtime parameter '{key}' updated: {prior} → {coerced}")
 
         if key in self.update_callbacks:
             for callback in self.update_callbacks[key]:
                 try:
-                    callback(coerced, old_value)
+                    callback(coerced, prior)
                 except Exception as e:
                     print(f"Error in parameter update callback for '{key}': {e}")
         return True
@@ -353,8 +354,7 @@ class LoRaRuntimeManager:
             
             # Handle legacy format (backward compatibility)
             if payload == '21':
-                self.set_parameter('emergency_mode', True)
-                return True
+                return self.set_parameter('emergency_mode', True)
             
             # First try TLV hex multi-command format: [ch:1B][cmd:1B][len:1B][value:len]
             def _is_hex_string(s: str) -> bool:
@@ -533,11 +533,13 @@ class LoRaRuntimeManager:
             # Validate/coerce all changes in-memory first, then persist once.
             # Avoids one save_parameters() call per changed key on constrained hardware.
             changes = []
+            prior_values = {}
             for key, value in lora_config.items():
                 if key in self.parameters and self.parameters[key] != value:
                     old_value = self.parameters[key]
                     if self._validate_param(key, value):
                         coerced = self._coerce_param(key, value)
+                        prior_values[key] = old_value
                         self.parameters[key] = coerced
                         changes.append(f"{key}: {old_value} → {coerced}")
                     else:
@@ -545,6 +547,8 @@ class LoRaRuntimeManager:
 
             if changes:
                 if not self.save_parameters(self.parameters):
+                    for key, old_value in prior_values.items():
+                        self.parameters[key] = old_value
                     print(f"Warning: failed to persist {len(changes)} synced parameter(s) to disk")
                     return False
                 print(f"🔄 Synced {len(changes)} parameters from LoRa config:")

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -97,7 +97,7 @@ class LoRaRuntimeManager:
     # Values outside these ranges are rejected with a warning.
     _PARAM_RANGES: dict = {
         'area_threshold':                   (0, 100),
-        'stage_threshold':                  (0, 1000),
+        'stage_threshold':                  (0, 255),
         'monitoring_frequency':             (1, 10080),
         'emergency_frequency':              (1, 1440),
         'photo_interval':                   (1, 1440),
@@ -240,12 +240,13 @@ class LoRaRuntimeManager:
         if not math.isfinite(numeric):
             print(f"Warning: non-finite value {value!r} for parameter '{key}', rejected")
             return False
-        # Reject fractional values for integer-only params (e.g. 1.9 must not silently become 1)
-        if key in self._INT_PARAMS and numeric != int(numeric):
-            print(f"Warning: fractional value {value} for integer parameter '{key}', rejected")
-            return False
+        # Range check before fractional check: avoids int() on huge finite floats
         if not (lo <= numeric <= hi):
             print(f"Warning: value {value} for '{key}' is outside allowed range [{lo}, {hi}], rejected")
+            return False
+        # Reject fractional values for integer-only params (e.g. 1.9 must not silently become 1)
+        if key in self._INT_PARAMS and not numeric.is_integer():
+            print(f"Warning: fractional value {value} for integer parameter '{key}', rejected")
             return False
         return True
 

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -279,10 +279,14 @@ class LoRaRuntimeManager:
         if not self._validate_param(key, value):
             return False
         coerced = self._coerce_param(key, value)
-        old_value = self.parameters.get(key)
+        _MISSING = object()
+        old_value = self.parameters.get(key, _MISSING)
         self.parameters[key] = coerced
         if not self.save_parameters(self.parameters):
-            self.parameters[key] = old_value
+            if old_value is _MISSING:
+                del self.parameters[key]
+            else:
+                self.parameters[key] = old_value
             print(f"Warning: failed to persist '{key}', change rolled back")
             return False
 
@@ -395,7 +399,7 @@ class LoRaRuntimeManager:
                 if channel == '10' and command == '90':
                     return _set('area_threshold', val_int * 10)
                 elif channel == '11' and command == '91':
-                    return _set('stage_threshold', float(val_int))
+                    return _set('stage_threshold', val_int)
                 elif channel == '12' and command == '92':
                     return _set('monitoring_frequency', val_int)
                 elif channel == '13' and command == '93':


### PR DESCRIPTION
…ing (#37)

Channel, command, and value fields were sliced from raw bytes and applied directly to runtime parameters with no bounds checking. A malformed or replayed packet could set frequencies or thresholds to out-of-range values. Add _PARAM_RANGES class attribute with (min, max) for each settable param and _validate_param() that rejects and logs any value outside its range. Both the TLV and string-format dispatch paths now call _validate_param before set_parameter.