### PR TITLE
fix: normalize directory path in transform cache save/load

### DIFF
--- a/tools/coreg_multiple.py
+++ b/tools/coreg_multiple.py
@@ -149,7 +149,8 @@ def save_transform_parameters(transform: sitk.Transform, directory: str, metadat
             "timestamp": pd.Timestamp.now().isoformat(),
             "metadata": metadata if metadata is not None else {},
         }
-        parent_directory = os.path.dirname(directory) or directory
+        normed = os.path.normpath(directory)
+        parent_directory = os.path.dirname(normed) or normed
         transform_path = os.path.join(parent_directory, config.TRANSFORM_CACHE_FILENAME)
         with open(transform_path, "w") as f:
             json.dump(transform_data, f, indent=2)
@@ -162,7 +163,8 @@ def save_transform_parameters(transform: sitk.Transform, directory: str, metadat
 def load_transform_parameters(directory: str) -> Optional[tuple[sitk.Transform, str]]:
     if config.FORCE_RECALCULATE_TRANSFORM:
         return None
-    parent_directory = os.path.dirname(directory) or directory
+    normed = os.path.normpath(directory)
+    parent_directory = os.path.dirname(normed) or normed
     transform_path = os.path.join(parent_directory, config.TRANSFORM_CACHE_FILENAME)
     if not os.path.exists(transform_path):
         transform_path = os.path.join(directory, config.TRANSFORM_CACHE_FILENAME)


### PR DESCRIPTION
## Summary
- `os.path.dirname()` received an already-directory path, causing the cache file to be written one level too high
- Adds `os.path.normpath()` before `dirname()` so the cache resolves correctly regardless of trailing slash

## Linked issue
Closes #2

## Test plan
- [ ] Run coregistration with an existing cache file and confirm it loads from the correct path
- [ ] Confirm a new cache is written to the expected directory, not its parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)