### PR TITLE
fix: guard Picamera2 lazy init with threading.Lock to prevent TOCTOU race

### DIFF
--- a/tt_take_photos.py
+++ b/tt_take_photos.py
@@ -5,7 +5,11 @@
 # Call add_metadata to get info from IMU and GPS
 # Run lepton and capture binaries to save data from Flir in same directory
 
+import threading
+
 from ticktalkpython.SQ import SQify
+
+_camera_lock = threading.Lock()
 
 def take_photo(directory: str, nir: str, picam2) -> str:
     from os import path #, makedirs, chdir
@@ -164,13 +168,13 @@ def take_two_photos(trigger, directory):
 
     global sq_state
     try:
-        picam = sq_state.get("picam", None)
-        if picam is None:
-            picam2 = Picamera2()
-            config = picam2.create_still_configuration(main={"format": "RGB888", "size": (2592,1944)})
-            picam2.configure(config)
-            sq_state['picam'] = picam2
-        picam2 = sq_state['picam']
+        with _camera_lock:
+            if sq_state.get("picam") is None:
+                picam2 = Picamera2()
+                config = picam2.create_still_configuration(main={"format": "RGB888", "size": (2592, 1944)})
+                picam2.configure(config)
+                sq_state["picam"] = picam2
+        picam2 = sq_state["picam"]
     except Exception:
         print("Camera loading error")
         return True


### PR DESCRIPTION
## Summary
- Concurrent SQ state machine nodes could both evaluate the `if camera is None` check simultaneously and each attempt to initialize `Picamera2`, resulting in double-init and hardware errors
- Added a `threading.Lock` around the lazy init check-and-set so only one thread initializes the camera

## Linked issue
Closes #40

## Test plan
- [ ] Trigger concurrent camera access from multiple threads — confirm only one init occurs
- [ ] Confirm camera operates normally in single-threaded use

🤖 Generated with [Claude Code](https://claude.com/claude-code)