### PR TITLE
fix: log warning when BNO055 warmup exhausts without valid Euler data

### DIFF
--- a/tools/bno055_imu.py
+++ b/tools/bno055_imu.py
@@ -2,7 +2,10 @@
 # BNO055 IMU
 # Based on Adafruit example
 
+import logging
 import time
+
+logger = logging.getLogger(__name__)
 
 try:
     import board
@@ -36,6 +39,10 @@ def _get_sensor():
                 if isinstance(e, tuple) and any(v not in (None, 0.0) for v in e):
                     break
                 _t.sleep(0.1)
+            else:
+                e = getattr(_sensor, 'euler', None)
+                if not (isinstance(e, tuple) and any(v not in (None, 0.0) for v in e)):
+                    logger.warning("BNO055 warmup timed out — fusion not yet initialised")
         except Exception:
             pass
         return _sensor
@@ -82,6 +89,9 @@ def get_orientation():
                 if isinstance(e, tuple) and any(v not in (None, 0.0) for v in e):
                     break
                 _t.sleep(0.1)
+            else:
+                if not (isinstance(e, tuple) and any(v not in (None, 0.0) for v in e)):
+                    logger.warning("BNO055 get_orientation: data still zero after retry")
         except Exception:
             pass
     return {"tilt_roll_yaw": e}


### PR DESCRIPTION
## Summary
- The BNO055 warmup loop spun silently until timeout when the sensor failed to produce valid Euler angles, giving the caller no indication of failure
- Added a warning log after the loop exits without valid data so failures are visible in the system log

## Linked issue
Closes #41

## Test plan
- [ ] Run with a BNO055 that never produces valid data (simulate by capping iterations) — confirm warning is logged
- [ ] Run with a healthy sensor — confirm no spurious warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)