### PR TITLE
fix: write numeric float values to AHT20 CSV instead of formatted strings

### DIFF
--- a/tools/aht20_temperature.py
+++ b/tools/aht20_temperature.py
@@ -38,10 +38,11 @@ def record_csv():
             print("AHT20 unavailable")
             sleep(60)
             continue
-        row = {'Time':datetime.now().strftime('%Y%m%d-%H%M%S'),
-               'Temp': '%0.1f C' % sensor.temperature, 'Humidity': '%0.1f %%' %
-               sensor.relative_humidity}
-        print(row)
+        temp_c = round(float(sensor.temperature), 1)
+        hum_pct = round(float(sensor.relative_humidity), 1)
+        ts = datetime.now().strftime('%Y%m%d-%H%M%S')
+        print(f"Time: {ts}  Temp: {temp_c} C  Humidity: {hum_pct} %")
+        row = {'Time': ts, 'Temp': temp_c, 'Humidity': hum_pct}
 
         with open(FILE, 'a+', newline='') as out:
             DictWriter(out, row.keys()).writerow(row)


### PR DESCRIPTION
## Summary
- AHT20 temperature and humidity were written to CSV as pre-formatted strings (e.g. `\"23.45°C\"`), making downstream numeric parsing fail
- Changed to write raw `float` values; unit labels belong in the CSV header, not the data cells

## Linked issue
Closes #43

## Test plan
- [ ] Capture an AHT20 reading and inspect the CSV — confirm values are numeric floats
- [ ] Confirm existing code that reads the CSV can parse the values without stripping unit labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)