### PR TITLE
fix: privatize _get_packet() and eliminate implicit None return in get_location()

### DIFF
--- a/tools/get_gps.py
+++ b/tools/get_gps.py
@@ -12,47 +12,43 @@ except Exception:
     pass
 
 
-def get_packet():
+def _get_packet():
     if not _gps_available:
         return None
     packet = gpsd.get_current()
     print(f'Current packet mode: {packet.mode}')
-
     if packet.mode < 2:
         return None
-    else:
-        return packet
+    return packet
 
 def get_location() -> List[str]:
     if not _gps_available:
         return []
-    packet = get_packet()
+    packet = _get_packet()
     if not packet:
         return []
 
-    elif packet.mode >= 2:
-        gps_data = [
-            f"GPS Time UTC: {packet.time}\n",
-            f"Time Local: {time.asctime(time.localtime(time.time()))}\n",
-            f"Latitude: {packet.lat} degrees\n",
-            f"Longitude: {packet.lon} degrees\n",
-            f"Track: {packet.track}\n",
-            f"Satellites: {packet.sats}\n",
-            f"Error: {packet.error}\n",
-            f"Precision: {packet.position_precision()}\n",
-            f"Map URL: {packet.map_url()}\n",
-            f"Device: {gpsd.device()}\n"]
-
-        if packet.mode >= 3:
-            gps_data.append(f"Altitude: {packet.alt}\n")
-
-        return gps_data
+    gps_data = [
+        f"GPS Time UTC: {packet.time}\n",
+        f"Time Local: {time.asctime(time.localtime(time.time()))}\n",
+        f"Latitude: {packet.lat} degrees\n",
+        f"Longitude: {packet.lon} degrees\n",
+        f"Track: {packet.track}\n",
+        f"Satellites: {packet.sats}\n",
+        f"Error: {packet.error}\n",
+        f"Precision: {packet.position_precision()}\n",
+        f"Map URL: {packet.map_url()}\n",
+        f"Device: {gpsd.device()}\n",
+    ]
+    if packet.mode >= 3:
+        gps_data.append(f"Altitude: {packet.alt}\n")
+    return gps_data
 
 def _get_lat_lon_alt_with_packet() -> Tuple[dict, Optional[Any]]:
     """Internal function that returns GPS data and packet."""
     if not _gps_available:
         return ({}, None)
-    packet = get_packet()
+    packet = _get_packet()
 
     if not packet:
         return ({}, None)


### PR DESCRIPTION
## Summary
- `get_packet()` was a public function only used internally; renamed to `_get_packet()` so external callers cannot receive `None` where the public API contract returns `{}`
- `get_location()` had a dead `elif packet.mode >= 2` branch after an early `return []`, leaving an implicit `None` return path if the condition somehow missed — replaced with unconditional block

## Linked issue
Closes #44

## Test plan
- [ ] Confirm all callers (`get_location`, `get_lat_lon_alt`, `get_location_with_retry`) still return `{}` or `[]` when GPS unavailable
- [ ] Confirm no external code references `get_packet` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)