### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mandeeps/SU-WaterCam/security/code-scanning/1](https://github.com/mandeeps/SU-WaterCam/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (recommended here since there is only one job and all steps are read/test oriented). Use least privilege:

- `contents: read`

This preserves existing functionality (`actions/checkout` and test execution) while constraining `GITHUB_TOKEN`.

### Exact change
- File: `.github/workflows/ci.yml`
- Insert after the `on:` trigger block (before `jobs:`) a root-level permissions section:
  ```yml
  permissions:
    contents: read
  ```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
