### PR TITLE
fix: SF-adaptive bitmap compression and headerless raw-mode transmission

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -74,3 +74,4 @@ instructions/Flir_Lepton_v1_wiring.png filter=lfs diff=lfs merge=lfs -text
 instructions/SD_Install_0.png filter=lfs diff=lfs merge=lfs -text
 instructions/SD_Install_2.png filter=lfs diff=lfs merge=lfs -text
 instructions/Serial_TTL_Adapter.png filter=lfs diff=lfs merge=lfs -text
+*.stl filter=lfs diff=lfs merge=lfs -text

--- a/docs/BITMAP_SF_ADAPTIVE_COMPRESSION.md
+++ b/docs/BITMAP_SF_ADAPTIVE_COMPRESSION.md
@@ -95,6 +95,14 @@ budget. The only missing piece was that `compress_bitmap()` was not passing the 
 minimum). This case is now handled explicitly: `compress_bitmap()` returns `b''` and
 `lora_token()` skips transmission with a log message.
 
+## UART Inter-Process Lock
+
+`LoRaHandler` uses `fcntl.lockf` on `/run/lock/watercam-lora.lock` to serialize
+UART access across concurrent processes. The file is created with mode `0o600`
+(owner-only) to prevent symlink/hardlink attacks. `/run/lock` is a tmpfs directory
+cleared on reboot — if diagnosing UART contention issues, check for stale holders
+with `lsof /run/lock/watercam-lora.lock`.
+
 ## Server-Side Counterpart
 
 The WaterCam API also needed a fix: its raw bitmap detection only accepted `method == 0`

--- a/docs/BITMAP_SF_ADAPTIVE_COMPRESSION.md
+++ b/docs/BITMAP_SF_ADAPTIVE_COMPRESSION.md
@@ -75,14 +75,14 @@ sending zero-byte payloads to the mDot.
 
 ## Payload Budget by SF (US915)
 
-| SF | Limit | Mode | Bitmap budget | vs. old (always 228 B) |
+| SF | LoRaWAN limit | Mode | Bitmap budget | Old behaviour |
 |---|---|---|---|---|
-| SF7 / 500 kHz | 242 B | tokenized | 228 B | unchanged |
-| SF7 / 125 kHz | 133 B | tokenized | 119 B | **+119 B** (was 228, truncated) |
-| SF8 / 500 kHz | 125 B | **raw** | 125 B | **+125 B** (was 228, truncated) |
-| SF8 / 125 kHz | 61 B | **raw** | 61 B | **+61 B** (was 228, truncated) |
-| SF9 | 53 B | **raw** | 53 B | **+53 B** (was 228, truncated) |
-| SF12 | ~11 B | **raw** | 11 B (likely no fit) | was truncated |
+| SF7 / 500 kHz | 242 B | tokenized | 228 B | 228 B — fits, unchanged |
+| SF7 / 125 kHz | 133 B | tokenized | 119 B | 228 B sent → **truncated to 133 B** |
+| SF8 / 500 kHz | 125 B | **raw** | 125 B | 228 B sent → **truncated to 125 B** |
+| SF8 / 125 kHz | 61 B | **raw** | 61 B | 228 B sent → **truncated to 61 B** |
+| SF9 | 53 B | **raw** | 53 B | 228 B sent → **truncated to 53 B** |
+| SF12 | ~11 B | **raw** | skipped (< 32 B min) | 228 B sent → truncated, unusable |
 
 ## Interaction with `compress_segmented.py`
 

--- a/docs/BITMAP_SF_ADAPTIVE_COMPRESSION.md
+++ b/docs/BITMAP_SF_ADAPTIVE_COMPRESSION.md
@@ -1,0 +1,103 @@
+# Bitmap SF-Adaptive Compression — Device-Side Changes
+
+**Date:** May 2026  
+**Related repo:** WaterCam API (`fix/bitmap-sf-adaptive-raw-mode`)  
+**Affected files:** `ticktalk_main.py`
+
+---
+
+## Problem
+
+Bitmaps transmitted over LoRaWAN arrived at the server as truncated Brotli streams,
+causing `Unexpected EOF` on every decompression attempt. All 26 bitmaps in the InfluxDB
+backlog were affected.
+
+## Root Cause
+
+The device always compressed bitmaps to ≤228 B (`compress_segmented.py` default), which
+accounts for the 14-byte TTLoRa header overhead at SF7 (242 B LoRaWAN limit). When the
+mDot operated at SF8 or higher, the LoRaWAN gateway truncated the payload to the SF's
+hard limit without any error indication to the device.
+
+The `LoRaHandler.current_size_limit` field tracked the mDot-reported payload budget
+(updated via `+TXS:` AT responses), and `_attempt_transmission()` correctly rejected
+payloads exceeding it. However, if `current_size_limit` had not yet been updated from
+its default of 242 B (e.g., first boot, `+TXS:` not yet received), the check would pass
+even when the actual SF limit was much smaller. The device would send the packet, the
+gateway would truncate it, and the server received incomplete data.
+
+Even when `current_size_limit` was correctly set, the size was checked *after* compression
+— meaning the bitmap was already compressed to 228 B for a budget of, say, 53 B. The
+`_attempt_transmission()` rejection prevented the send, but the bitmap was not re-compressed
+at the correct size.
+
+## Fix
+
+### `_BITMAP_RAW_MODE_THRESHOLD = 128`
+
+Defines the LoRaWAN payload budget (in bytes) below which the device switches to raw
+transmission mode. Threshold of 128 B corresponds approximately to SF8/US915 500 kHz
+(125 B limit); SF7 (133–242 B) uses tokenized mode.
+
+### `compress_bitmap()` — SF-aware sizing
+
+Before calling `compress_image()`, the function now queries `get_size_limit()` from the
+`LoRaHandler` singleton. This returns the budget last reported by the mDot (defaulting
+to 242 B if no `+TXS:` response has been received yet).
+
+Two modes:
+
+| Condition | `max_bytes` passed to `compress_image()` | Why |
+|---|---|---|
+| `lora_limit > 128` | `lora_limit − 14` | Leave 14 B for TTLoRa header |
+| `lora_limit ≤ 128` | `lora_limit` | Full budget; no header in raw mode |
+
+`compress_image()` runs a binary search (`find_best_size()`) to find the largest image
+dimension that produces a compressed payload within `max_bytes`. If even a 32×32 image
+exceeds the budget, `compress_bitmap()` returns `b''` and no transmission is attempted.
+
+### `lora_token()` / `lora_token_with_tracker()` — conditional TTToken wrapping
+
+Using the same threshold, the function decides how to transmit:
+
+**Raw mode** (`lora_limit ≤ 128`):
+- Sends bare bitmap bytes via `handler.queue_binary_transmit(bitmap)`.
+- No TTToken/TTLoRa header — saves 14 bytes for actual image data.
+- The server API's raw bitmap detection path handles this format
+  (`app/chirpstack.py` lines 645–670 in the WaterCam API repo).
+
+**Tokenized mode** (`lora_limit > 128`):
+- Sends TTToken-wrapped bitmap (14-byte TTLoRa header + bitmap).
+- Also sends bare bitmap bytes as before (dual transmission for redundancy).
+
+Both functions now guard against an empty bitmap (`if not bitmap: return early`) to avoid
+sending zero-byte payloads to the mDot.
+
+## Payload Budget by SF (US915)
+
+| SF | Limit | Mode | Bitmap budget | vs. old (always 228 B) |
+|---|---|---|---|---|
+| SF7 / 500 kHz | 242 B | tokenized | 228 B | unchanged |
+| SF7 / 125 kHz | 133 B | tokenized | 119 B | **+119 B** (was 228, truncated) |
+| SF8 / 500 kHz | 125 B | **raw** | 125 B | **+125 B** (was 228, truncated) |
+| SF8 / 125 kHz | 61 B | **raw** | 61 B | **+61 B** (was 228, truncated) |
+| SF9 | 53 B | **raw** | 53 B | **+53 B** (was 228, truncated) |
+| SF12 | ~11 B | **raw** | 11 B (likely no fit) | was truncated |
+
+## Interaction with `compress_segmented.py`
+
+`compress_segmented.py` was already correct — `find_best_size()` binary-searches for the
+largest image that fits within `max_bytes`, so it naturally adapts when given a smaller
+budget. The only missing piece was that `compress_bitmap()` was not passing the right
+`max_bytes` value.
+
+`compress_image()` may return `{'success': False}` when no image fits (budget < 32 B
+minimum). This case is now handled explicitly: `compress_bitmap()` returns `b''` and
+`lora_token()` skips transmission with a log message.
+
+## Server-Side Counterpart
+
+The WaterCam API also needed a fix: its raw bitmap detection only accepted `method == 0`
+(bitpacked + Brotli). Method 1 (RLE + Brotli) bitmaps — which `compress_image()` may
+choose when they produce a smaller output — were being silently discarded. This is fixed
+in `app/chirpstack.py` in the companion PR.

--- a/docs/IP_TRANSMISSION.md
+++ b/docs/IP_TRANSMISSION.md
@@ -385,9 +385,9 @@ calls — zero overhead for LoRa-only deployments.
 
 ## Known Gaps / Next Steps
 
-1. **Full image upload** — the current `/ip/uplink` channel scheme only carries
-   the compressed bitmap.  A separate `POST /ip/image` endpoint would be needed
-   on the server side to receive full-resolution JPG/PGM/CSV files.
+1. **Full image upload** — not applicable.  Raw camera files (JPG/PGM/CSV) are
+   never transmitted; the compressed flood bitmap via channel `08 18` is the
+   intended image payload.
 2. **Auth** — if the server gains API key auth, populate `api_key` in config and
    update the server to check `Authorization: Bearer <key>` headers.
 3. **GPS decoder bug — fixed (API commit 0a63091)** — `decode_gps_8b` in

--- a/tests/test_bitmap_sf_adaptive.py
+++ b/tests/test_bitmap_sf_adaptive.py
@@ -1,0 +1,209 @@
+"""Tests for SF-adaptive bitmap compression and raw/tokenized mode selection."""
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_handler(size_limit: int) -> MagicMock:
+    handler = MagicMock()
+    handler.get_size_limit.return_value = size_limit
+    handler.current_size_limit = size_limit
+    return handler
+
+
+def _fake_compress_image(input_path, max_bytes=228, min_size=32, **_):
+    """Stub compress_image: succeeds if max_bytes >= 32, returns a payload of max_bytes."""
+    if max_bytes < 32:
+        return {"success": False}
+    # method byte (0) + 2B width + 2B height + payload
+    fake_data = bytes([0, 0, 32, 0, 32]) + b"\x00" * (max_bytes - 5)
+    return {
+        "success": True,
+        "compressed_data": fake_data[:max_bytes],
+        "total_size": max_bytes,
+        "width": 32,
+        "height": 32,
+        "method": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# compress_bitmap: max_bytes selection
+# ---------------------------------------------------------------------------
+
+class TestCompressBitmapBudget:
+    """compress_bitmap() must pass the correct max_bytes to compress_image()."""
+
+    def _call(self, lora_limit, captured):
+        """Invoke compress_bitmap's core logic in isolation."""
+        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD
+
+        if lora_limit <= _BITMAP_RAW_MODE_THRESHOLD:
+            expected_max = lora_limit
+        else:
+            expected_max = lora_limit - 14
+
+        with patch("tools.lora_handler_concurrent.get_size_limit", return_value=lora_limit), \
+             patch("tools.compress_segmented.compress_image",
+                   side_effect=lambda path, max_bytes=228, **kw: (
+                       captured.__setitem__("max_bytes", max_bytes) or
+                       _fake_compress_image(path, max_bytes=max_bytes)
+                   )):
+            import importlib, sys
+            # Import function directly to avoid @SQify wrapper complications
+            import types as _types
+            import tools.compress_segmented as _cs
+            import tools.lora_handler_concurrent as _lh
+            from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
+
+            get_size_limit = _lh.get_size_limit
+            compress_image = _cs.compress_image
+
+            lora_limit_val = get_size_limit()
+            max_bitmap_bytes = 228
+            if lora_limit_val <= THR:
+                max_bitmap_bytes = lora_limit_val
+            else:
+                max_bitmap_bytes = lora_limit_val - 14
+            result = compress_image("fake.png", max_bytes=max_bitmap_bytes)
+            captured["max_bytes"] = max_bitmap_bytes
+            return result, expected_max
+
+    def test_sf7_tokenized_mode(self):
+        """SF7/500kHz (242B) → tokenized, max_bytes = 228."""
+        cap = {}
+        _, expected = self._call(242, cap)
+        assert cap["max_bytes"] == expected == 228
+
+    def test_sf7_125khz_tokenized_mode(self):
+        """SF7/125kHz (133B) → tokenized, max_bytes = 119."""
+        cap = {}
+        _, expected = self._call(133, cap)
+        assert cap["max_bytes"] == expected == 119
+
+    def test_sf8_raw_mode(self):
+        """SF8/500kHz (125B) ≤ 128 → raw, max_bytes = 125 (full budget)."""
+        cap = {}
+        _, expected = self._call(125, cap)
+        assert cap["max_bytes"] == expected == 125
+
+    def test_sf9_raw_mode(self):
+        """SF9 (53B) → raw, max_bytes = 53."""
+        cap = {}
+        _, expected = self._call(53, cap)
+        assert cap["max_bytes"] == expected == 53
+
+    def test_at_threshold_boundary(self):
+        """Limit == threshold (128B) → raw mode."""
+        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
+        cap = {}
+        _, expected = self._call(THR, cap)
+        assert cap["max_bytes"] == expected == THR  # raw: full budget
+
+    def test_just_above_threshold(self):
+        """Limit == threshold + 1 → tokenized mode."""
+        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
+        cap = {}
+        _, expected = self._call(THR + 1, cap)
+        assert cap["max_bytes"] == expected == THR + 1 - 14
+
+
+# ---------------------------------------------------------------------------
+# compress_bitmap: degenerate cases
+# ---------------------------------------------------------------------------
+
+class TestCompressBitmapEdgeCases:
+
+    def _run_compress_bitmap(self, lora_limit, compress_result):
+        """Run the compress_bitmap logic (extracted from @SQify wrapper)."""
+        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
+
+        if lora_limit <= THR:
+            max_bitmap_bytes = lora_limit
+        else:
+            max_bitmap_bytes = lora_limit - 14
+
+        if max_bitmap_bytes < 32:
+            return b''
+
+        if not compress_result.get("success"):
+            return b''
+        return compress_result["compressed_data"]
+
+    def test_too_small_budget_returns_empty(self):
+        """Budget < 32 B after header → return b'' immediately."""
+        result = self._run_compress_bitmap(20, {"success": True, "compressed_data": b"x"})
+        assert result == b''
+
+    def test_compress_failure_returns_empty(self):
+        """compress_image success=False → return b''."""
+        result = self._run_compress_bitmap(242, {"success": False})
+        assert result == b''
+
+    def test_successful_compression_returns_data(self):
+        """Successful compression returns the compressed bytes."""
+        data = bytes([0, 0, 32, 0, 32]) + b"\x00" * 100
+        result = self._run_compress_bitmap(242, {"success": True, "compressed_data": data})
+        assert result == data
+
+
+# ---------------------------------------------------------------------------
+# Transmission mode: raw vs tokenized
+# ---------------------------------------------------------------------------
+
+class TestTransmissionMode:
+    """lora_token() should use bare bytes below threshold, TTToken above it."""
+
+    def test_raw_mode_below_threshold(self):
+        """At SF8 (125B ≤ 128) transmission must skip TTToken wrapping."""
+        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
+        lora_limit = 125
+        assert lora_limit <= THR, "precondition: raw mode"
+
+        handler = _make_mock_handler(lora_limit)
+        bitmap = b"\x00" * 50  # small compressed bitmap
+
+        # Simulate the mode branch from lora_token()
+        _use_raw_mode = lora_limit <= THR
+        if _use_raw_mode:
+            handler.queue_binary_transmit(bitmap)
+            handler.process_transmit_queue()
+
+        handler.queue_binary_transmit.assert_called_once_with(bitmap)
+        handler.process_transmit_queue.assert_called_once()
+
+    def test_tokenized_mode_above_threshold(self):
+        """At SF7 (242B > 128) TTToken path executes; bare bytes also queued."""
+        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
+        lora_limit = 242
+        assert lora_limit > THR, "precondition: tokenized mode"
+
+        handler = _make_mock_handler(lora_limit)
+        bitmap = b"\x00" * 100
+        packet2_hex = "aabbcc"
+
+        # Simulate the tokenized branch (mocking TTToken)
+        _use_raw_mode = lora_limit <= THR
+        assert not _use_raw_mode
+        handler.queue_binary_transmit(packet2_hex)  # tokenized
+        handler.queue_binary_transmit(bitmap)        # bare
+        handler.process_transmit_queue()
+
+        assert handler.queue_binary_transmit.call_count == 2
+        handler.process_transmit_queue.assert_called_once()
+
+    def test_empty_bitmap_skips_transmission(self):
+        """lora_token() must not call queue_binary_transmit for empty bitmap."""
+        handler = _make_mock_handler(242)
+        bitmap = b''
+
+        if not bitmap:
+            pass  # guard fires — no transmission
+        else:
+            handler.queue_binary_transmit(bitmap)
+
+        handler.queue_binary_transmit.assert_not_called()

--- a/tests/test_bitmap_sf_adaptive.py
+++ b/tests/test_bitmap_sf_adaptive.py
@@ -1,29 +1,26 @@
-"""Tests for SF-adaptive bitmap compression and raw/tokenized mode selection."""
-import types
-from unittest.mock import MagicMock, patch
+"""Tests for SF-adaptive bitmap compression and raw/tokenized mode selection.
 
-import pytest
+All tests call the real production functions via __wrapped__ (SQify uses
+functools.wraps so __wrapped__ points to the original) with hardware
+dependencies patched.  This ensures regressions in compress_bitmap() and
+lora_token() are caught rather than just testing re-implemented logic.
+"""
+import contextlib
+from unittest.mock import MagicMock, patch, call
+
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers / fixtures
 # ---------------------------------------------------------------------------
 
-def _make_mock_handler(size_limit: int) -> MagicMock:
-    handler = MagicMock()
-    handler.get_size_limit.return_value = size_limit
-    handler.current_size_limit = size_limit
-    return handler
-
-
-def _fake_compress_image(input_path, max_bytes=228, min_size=32, **_):
-    """Stub compress_image: succeeds if max_bytes >= 32, returns a payload of max_bytes."""
+def _fake_compress_image(path, max_bytes=228, min_size=32, **_):
+    """Stub: succeed for max_bytes ≥ 32, return payload exactly max_bytes long."""
     if max_bytes < 32:
         return {"success": False}
-    # method byte (0) + 2B width + 2B height + payload
-    fake_data = bytes([0, 0, 32, 0, 32]) + b"\x00" * (max_bytes - 5)
+    data = bytes([0, 0, 32, 0, 32]) + b"\x00" * (max_bytes - 5)
     return {
         "success": True,
-        "compressed_data": fake_data[:max_bytes],
+        "compressed_data": data,
         "total_size": max_bytes,
         "width": 32,
         "height": 32,
@@ -31,179 +28,173 @@ def _fake_compress_image(input_path, max_bytes=228, min_size=32, **_):
     }
 
 
+def _make_lora_handler(size_limit: int) -> MagicMock:
+    h = MagicMock()
+    h.get_size_limit.return_value = size_limit
+    h.current_size_limit = size_limit
+    h.queue_binary_transmit.return_value = True
+    h.process_transmit_queue.return_value = None
+    h.queue_transmit.return_value = True
+    return h
+
+
 # ---------------------------------------------------------------------------
-# compress_bitmap: max_bytes selection
+# compress_bitmap tests — call the real __wrapped__ function
 # ---------------------------------------------------------------------------
 
 class TestCompressBitmapBudget:
-    """compress_bitmap() must pass the correct max_bytes to compress_image()."""
+    """compress_bitmap().__wrapped__ must pass the right max_bytes to compress_image."""
 
-    def _call(self, lora_limit, captured):
-        """Invoke compress_bitmap's core logic in isolation."""
-        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD
+    def _run(self, lora_limit):
+        import ticktalk_main
+        captured = {}
 
-        if lora_limit <= _BITMAP_RAW_MODE_THRESHOLD:
-            expected_max = lora_limit
-        else:
-            expected_max = lora_limit - 14
+        def capturing_compress(path, max_bytes=228, **kw):
+            captured["max_bytes"] = max_bytes
+            return _fake_compress_image(path, max_bytes=max_bytes)
 
         with patch("tools.lora_handler_concurrent.get_size_limit", return_value=lora_limit), \
-             patch("tools.compress_segmented.compress_image",
-                   side_effect=lambda path, max_bytes=228, **kw: (
-                       captured.__setitem__("max_bytes", max_bytes) or
-                       _fake_compress_image(path, max_bytes=max_bytes)
-                   )):
-            import importlib, sys
-            # Import function directly to avoid @SQify wrapper complications
-            import types as _types
-            import tools.compress_segmented as _cs
-            import tools.lora_handler_concurrent as _lh
-            from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
+             patch("tools.compress_segmented.compress_image", side_effect=capturing_compress):
+            data = ticktalk_main.compress_bitmap.__wrapped__("fake.png")
 
-            get_size_limit = _lh.get_size_limit
-            compress_image = _cs.compress_image
+        return data, captured["max_bytes"]
 
-            lora_limit_val = get_size_limit()
-            max_bitmap_bytes = 228
-            if lora_limit_val <= THR:
-                max_bitmap_bytes = lora_limit_val
-            else:
-                max_bitmap_bytes = lora_limit_val - 14
-            result = compress_image("fake.png", max_bytes=max_bitmap_bytes)
-            captured["max_bytes"] = max_bitmap_bytes
-            return result, expected_max
+    def test_sf7_500khz_tokenized(self):
+        data, max_bytes = self._run(242)
+        assert max_bytes == 228
+        assert len(data) == 228
 
-    def test_sf7_tokenized_mode(self):
-        """SF7/500kHz (242B) → tokenized, max_bytes = 228."""
-        cap = {}
-        _, expected = self._call(242, cap)
-        assert cap["max_bytes"] == expected == 228
+    def test_sf7_125khz_tokenized(self):
+        data, max_bytes = self._run(133)
+        assert max_bytes == 119
+        assert len(data) == 119
 
-    def test_sf7_125khz_tokenized_mode(self):
-        """SF7/125kHz (133B) → tokenized, max_bytes = 119."""
-        cap = {}
-        _, expected = self._call(133, cap)
-        assert cap["max_bytes"] == expected == 119
+    def test_sf8_500khz_raw(self):
+        """SF8/500kHz (125B ≤ 128) → raw mode → full 125B budget."""
+        data, max_bytes = self._run(125)
+        assert max_bytes == 125
+        assert len(data) == 125
 
-    def test_sf8_raw_mode(self):
-        """SF8/500kHz (125B) ≤ 128 → raw, max_bytes = 125 (full budget)."""
-        cap = {}
-        _, expected = self._call(125, cap)
-        assert cap["max_bytes"] == expected == 125
+    def test_sf9_raw(self):
+        data, max_bytes = self._run(53)
+        assert max_bytes == 53
 
-    def test_sf9_raw_mode(self):
-        """SF9 (53B) → raw, max_bytes = 53."""
-        cap = {}
-        _, expected = self._call(53, cap)
-        assert cap["max_bytes"] == expected == 53
-
-    def test_at_threshold_boundary(self):
-        """Limit == threshold (128B) → raw mode."""
+    def test_at_threshold_is_raw(self):
         from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
-        cap = {}
-        _, expected = self._call(THR, cap)
-        assert cap["max_bytes"] == expected == THR  # raw: full budget
+        data, max_bytes = self._run(THR)
+        assert max_bytes == THR
 
-    def test_just_above_threshold(self):
-        """Limit == threshold + 1 → tokenized mode."""
+    def test_one_above_threshold_is_tokenized(self):
         from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
-        cap = {}
-        _, expected = self._call(THR + 1, cap)
-        assert cap["max_bytes"] == expected == THR + 1 - 14
+        data, max_bytes = self._run(THR + 1)
+        assert max_bytes == THR + 1 - 14
 
-
-# ---------------------------------------------------------------------------
-# compress_bitmap: degenerate cases
-# ---------------------------------------------------------------------------
 
 class TestCompressBitmapEdgeCases:
 
-    def _run_compress_bitmap(self, lora_limit, compress_result):
-        """Run the compress_bitmap logic (extracted from @SQify wrapper)."""
-        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
-
-        if lora_limit <= THR:
-            max_bitmap_bytes = lora_limit
-        else:
-            max_bitmap_bytes = lora_limit - 14
-
-        if max_bitmap_bytes < 32:
-            return b''
-
-        if not compress_result.get("success"):
-            return b''
-        return compress_result["compressed_data"]
-
-    def test_too_small_budget_returns_empty(self):
-        """Budget < 32 B after header → return b'' immediately."""
-        result = self._run_compress_bitmap(20, {"success": True, "compressed_data": b"x"})
-        assert result == b''
+    def test_budget_below_min_returns_empty_without_calling_compress_image(self):
+        """Budget < 32B → immediate b'', compress_image never called."""
+        import ticktalk_main
+        with patch("tools.lora_handler_concurrent.get_size_limit", return_value=20), \
+             patch("tools.compress_segmented.compress_image") as mock_ci:
+            result = ticktalk_main.compress_bitmap.__wrapped__("fake.png")
+        assert result == b""
+        mock_ci.assert_not_called()
 
     def test_compress_failure_returns_empty(self):
-        """compress_image success=False → return b''."""
-        result = self._run_compress_bitmap(242, {"success": False})
-        assert result == b''
+        import ticktalk_main
+        with patch("tools.lora_handler_concurrent.get_size_limit", return_value=242), \
+             patch("tools.compress_segmented.compress_image",
+                   return_value={"success": False}):
+            result = ticktalk_main.compress_bitmap.__wrapped__("fake.png")
+        assert result == b""
 
-    def test_successful_compression_returns_data(self):
-        """Successful compression returns the compressed bytes."""
-        data = bytes([0, 0, 32, 0, 32]) + b"\x00" * 100
-        result = self._run_compress_bitmap(242, {"success": True, "compressed_data": data})
-        assert result == data
+    def test_handler_unavailable_falls_back_to_228(self):
+        """get_size_limit() raises → fall back to 228B default (tokenized)."""
+        import ticktalk_main
+        captured = {}
+
+        def capturing_compress(path, max_bytes=228, **kw):
+            captured["max_bytes"] = max_bytes
+            return _fake_compress_image(path, max_bytes=max_bytes)
+
+        with patch("tools.lora_handler_concurrent.get_size_limit",
+                   side_effect=RuntimeError("no mDot")), \
+             patch("tools.compress_segmented.compress_image",
+                   side_effect=capturing_compress):
+            result = ticktalk_main.compress_bitmap.__wrapped__("fake.png")
+
+        assert captured["max_bytes"] == 228
+        assert len(result) == 228
 
 
 # ---------------------------------------------------------------------------
-# Transmission mode: raw vs tokenized
+# lora_token bitmap path — call __wrapped__ with all dependencies patched
 # ---------------------------------------------------------------------------
 
-class TestTransmissionMode:
-    """lora_token() should use bare bytes below threshold, TTToken above it."""
+def _lora_token_patches(handler):
+    """Context-manager stack that patches every import inside lora_token."""
+    mock_token = MagicMock()
+    mock_lora_msg = MagicMock()
+    mock_lora_msg.encode_token.return_value = b"\xde\xad\xbe\xef"
 
-    def test_raw_mode_below_threshold(self):
-        """At SF8 (125B ≤ 128) transmission must skip TTToken wrapping."""
-        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
-        lora_limit = 125
-        assert lora_limit <= THR, "precondition: raw mode"
+    return [
+        patch("tools.lora_handler_concurrent.get_lora_handler", return_value=handler),
+        patch("tools.lora_handler_concurrent.get_config_value", return_value=None),
+        patch("tools.lora_handler_concurrent.transmit_data", return_value=True),
+        patch("tools.lora_handler_concurrent.transmit_binary", return_value=True),
+        patch("tools.lora_handler_concurrent.compressed_encoding", return_value=b"\x00" * 8),
+        patch("tools.bno055_imu.get_orientation", return_value={}),
+        patch("tools.aht20_temperature.get_aht20", return_value={}),
+        patch("tools.get_gps.get_location_with_retry", return_value=({}, None)),
+        patch("tools.wittypi_control.get_wittypi_status",
+              return_value={"status": "unavailable"}),
+        patch("tools.battery_manager.get_battery_status",
+              return_value={"battery_pct": 80, "battery_source": "test"}),
+        patch("tools.lora_runtime_integration.get_parameter", return_value=False),
+        patch("ticktalkpython.TTToken.TTToken", return_value=mock_token),
+        patch("ticktalkpython.NetworkInterfaceLoRa.TTLoRaMessage",
+              return_value=mock_lora_msg),
+        patch("pympler.asizeof.asizeof", return_value=100),
+    ]
 
-        handler = _make_mock_handler(lora_limit)
-        bitmap = b"\x00" * 50  # small compressed bitmap
 
-        # Simulate the mode branch from lora_token()
-        _use_raw_mode = lora_limit <= THR
-        if _use_raw_mode:
-            handler.queue_binary_transmit(bitmap)
-            handler.process_transmit_queue()
+class TestLoraTokenBitmapMode:
 
-        handler.queue_binary_transmit.assert_called_once_with(bitmap)
-        handler.process_transmit_queue.assert_called_once()
+    def _invoke(self, bitmap: bytes, lora_limit: int):
+        import ticktalk_main
+        handler = _make_lora_handler(lora_limit)
+        with contextlib.ExitStack() as stack:
+            for p in _lora_token_patches(handler):
+                stack.enter_context(p)
+            ticktalk_main.lora_token.__wrapped__(bitmap)
+        return handler
 
-    def test_tokenized_mode_above_threshold(self):
-        """At SF7 (242B > 128) TTToken path executes; bare bytes also queued."""
-        from ticktalk_main import _BITMAP_RAW_MODE_THRESHOLD as THR
-        lora_limit = 242
-        assert lora_limit > THR, "precondition: tokenized mode"
+    def test_raw_mode_queues_bare_bytes_only(self):
+        """SF8 (125B ≤ threshold): only bare bitmap bytes queued, no TTToken."""
+        bitmap = b"\x01" * 50
+        handler = self._invoke(bitmap, lora_limit=125)
 
-        handler = _make_mock_handler(lora_limit)
-        bitmap = b"\x00" * 100
-        packet2_hex = "aabbcc"
+        queued = [c.args[0] for c in handler.queue_binary_transmit.call_args_list]
+        assert bitmap in queued
+        # TTToken-encoded would be b"\xde\xad\xbe\xef".hex() — must NOT be present
+        assert b"\xde\xad\xbe\xef".hex() not in queued
 
-        # Simulate the tokenized branch (mocking TTToken)
-        _use_raw_mode = lora_limit <= THR
-        assert not _use_raw_mode
-        handler.queue_binary_transmit(packet2_hex)  # tokenized
-        handler.queue_binary_transmit(bitmap)        # bare
-        handler.process_transmit_queue()
+    def test_tokenized_mode_queues_both(self):
+        """SF7 (242B > threshold): TTToken hex AND bare bitmap both queued."""
+        bitmap = b"\x01" * 100
+        handler = self._invoke(bitmap, lora_limit=242)
 
-        assert handler.queue_binary_transmit.call_count == 2
-        handler.process_transmit_queue.assert_called_once()
+        queued = [c.args[0] for c in handler.queue_binary_transmit.call_args_list]
+        assert bitmap in queued
+        assert b"\xde\xad\xbe\xef".hex() in queued
 
-    def test_empty_bitmap_skips_transmission(self):
-        """lora_token() must not call queue_binary_transmit for empty bitmap."""
-        handler = _make_mock_handler(242)
-        bitmap = b''
-
-        if not bitmap:
-            pass  # guard fires — no transmission
-        else:
-            handler.queue_binary_transmit(bitmap)
-
-        handler.queue_binary_transmit.assert_not_called()
+    def test_empty_bitmap_skips_all_transmission(self):
+        """Empty bitmap b'' → lora_token returns without any queue_binary_transmit call for bitmap."""
+        handler = self._invoke(b"", lora_limit=242)
+        # Sensor data may be transmitted, but the bitmap-specific calls must not appear
+        bitmap_calls = [
+            c for c in handler.queue_binary_transmit.call_args_list
+            if c.args[0] == b""
+        ]
+        assert bitmap_calls == []

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -762,40 +762,20 @@ def segformer(filepath, coreg_state): # operate on coregistered image file
 
 @SQify
 def call_shutdown(state):
-    import fcntl
-    import json
-    import os
     import sys
     from subprocess import call
 
-    # Atomically increment iteration_count using a file lock so concurrent TT
-    # subprocesses (multiple overlapping STREAM firings) each see a distinct count.
-    cfg_path = os.path.join(
-        os.environ.get("WATERCAM_REPO", "/home/pi/SU-WaterCam"),
-        "runtime_config.json",
-    )
     new_count = 1
     auto_shutdown_enabled = True
     shutdown_limit = 3
     emergency_mode = False
 
     try:
-        with open(cfg_path, 'r+') as f:
-            fcntl.flock(f, fcntl.LOCK_EX)
-            try:
-                cfg = json.load(f)
-            except Exception:
-                cfg = {}
-            current_count = cfg.get('iteration_count', 0)
-            new_count = current_count + 1
-            cfg['iteration_count'] = new_count
-            auto_shutdown_enabled = cfg.get('auto_shutdown_enabled', True)
-            shutdown_limit = cfg.get('shutdown_iteration_limit', 3)
-            emergency_mode = cfg.get('emergency_mode', False)
-            f.seek(0)
-            json.dump(cfg, f, indent=2)
-            f.truncate()
-            fcntl.flock(f, fcntl.LOCK_UN)
+        result = get_runtime_manager().atomic_increment_iteration_count()
+        new_count = result['iteration_count']
+        auto_shutdown_enabled = result['auto_shutdown_enabled']
+        shutdown_limit = result['shutdown_iteration_limit']
+        emergency_mode = result['emergency_mode']
         print(f"\n Iteration: {new_count} \n")
     except Exception as e:
         print(f"⚠️ Failed to update iteration count: {e}")

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -797,15 +797,6 @@ def call_shutdown(state):
             f.truncate()
             fcntl.flock(f, fcntl.LOCK_UN)
         print(f"\n Iteration: {new_count} \n")
-        # Sync the in-memory LoRaRuntimeManager cache so it stays consistent
-        # with the file we just wrote directly.  call_shutdown() bypasses
-        # lora_runtime_integration (which has no file lock) to get atomic
-        # read-modify-write semantics; without this sync the in-memory cache
-        # would disagree with the file until the next set_parameter() call.
-        try:
-            set_parameter('iteration_count', new_count)
-        except Exception:
-            pass
     except Exception as e:
         print(f"⚠️ Failed to update iteration count: {e}")
 

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -810,7 +810,7 @@ def call_shutdown(state):
         print(f"\n🚨 SHUTDOWN TRIGGERED: {new_count} iterations >= {shutdown_limit} limit\n")
         try:
             # Preferred: graceful OS shutdown via doas (configured in /etc/doas.conf for user pi)
-            call("doas /usr/sbin/shutdown -h now", shell=True)
+            call(["doas", "/usr/sbin/shutdown", "-h", "now"])
         except Exception:
             pass
         # Fallback: terminate the TT runtime process

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -797,6 +797,15 @@ def call_shutdown(state):
             f.truncate()
             fcntl.flock(f, fcntl.LOCK_UN)
         print(f"\n Iteration: {new_count} \n")
+        # Sync the in-memory LoRaRuntimeManager cache so it stays consistent
+        # with the file we just wrote directly.  call_shutdown() bypasses
+        # lora_runtime_integration (which has no file lock) to get atomic
+        # read-modify-write semantics; without this sync the in-memory cache
+        # would disagree with the file until the next set_parameter() call.
+        try:
+            set_parameter('iteration_count', new_count)
+        except Exception:
+            pass
     except Exception as e:
         print(f"⚠️ Failed to update iteration count: {e}")
 

--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -19,6 +19,12 @@ from tools.lora_runtime_integration import (
 # Import LoRa handler
 from tools.lora_handler_concurrent import get_lora_handler
 
+# LoRaWAN payload budgets at which the 14-byte TTLoRa header becomes significant.
+# Below this threshold bitmaps are sent as raw bytes (no TTLoRa wrapper), gaining
+# 14 bytes for actual image data.  Above it, the full TTToken is used.
+# 128 B ≈ SF8/US915 500 kHz limit; SF7 (242 B) stays tokenized.
+_BITMAP_RAW_MODE_THRESHOLD = 128
+
 # Import helper functions
 from tools.wittypi_control import get_wittypi_status
 
@@ -398,22 +404,39 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
     except Exception as e:
         print(f"⚠️ Failed to transmit TTToken with sensor data: {e}")
 
-    try:
-        token_2 = TTToken(bitmap, time_1, False,
-        TTTag(context, sq_name, 4, recipient_device))
-        lora_msg2 = NetworkInterfaceLoRa.TTLoRaMessage(token_2, recipient_device)
-        encoded_msg2 = lora_msg2.encode_token()
-        packet2 = encoded_msg2.hex()
-        handler.queue_binary_transmit(packet2)
+    if not bitmap:
+        print("[lora_token_with_tracker] No bitmap data to transmit")
+    else:
+        try:
+            _lora_limit_for_bitmap = get_lora_handler().get_size_limit()
+        except Exception:
+            _lora_limit_for_bitmap = 242
+        _use_raw_bitmap_mode = _lora_limit_for_bitmap <= _BITMAP_RAW_MODE_THRESHOLD
 
-        handler.queue_binary_transmit(bitmap)
+        if _use_raw_bitmap_mode:
+            try:
+                handler.queue_binary_transmit(bitmap)
+                print(f"[lora_token_with_tracker] Raw bitmap mode: queued {len(bitmap)}B (mDot limit {_lora_limit_for_bitmap}B)")
+                handler.process_transmit_queue()
+            except Exception as e:
+                print(f"⚠️ Failed to transmit raw bitmap: {e}")
+        else:
+            try:
+                token_2 = TTToken(bitmap, time_1, False,
+                TTTag(context, sq_name, 4, recipient_device))
+                lora_msg2 = NetworkInterfaceLoRa.TTLoRaMessage(token_2, recipient_device)
+                encoded_msg2 = lora_msg2.encode_token()
+                packet2 = encoded_msg2.hex()
+                handler.queue_binary_transmit(packet2)
 
-        print(f" \n Size of Tokenized Bitmap object: {asizeof.asizeof(packet2)} \n")
-        print(f" \n Size of Tokenized Bitmap object getsizeof: {getsizeof(packet2)} \n")
-        handler.process_transmit_queue()
-    except Exception as e:
-        print(f"⚠️ Failed to transmit bitmap: {e}")
-    
+                handler.queue_binary_transmit(bitmap)
+
+                print(f" \n Size of Tokenized Bitmap object: {asizeof.asizeof(packet2)} \n")
+                print(f" \n Size of Tokenized Bitmap object getsizeof: {getsizeof(packet2)} \n")
+                handler.process_transmit_queue()
+            except Exception as e:
+                print(f"⚠️ Failed to transmit bitmap: {e}")
+
     # Update sensor tracker with transmission results
     if sensor_tracker:
         try:
@@ -739,48 +762,62 @@ def segformer(filepath, coreg_state): # operate on coregistered image file
 
 @SQify
 def call_shutdown(state):
+    import fcntl
+    import json
+    import os
     import sys
     from subprocess import call
-    from tools.lora_runtime_integration import get_parameter, set_parameter
 
-    # Get current iteration count from runtime parameters
+    # Atomically increment iteration_count using a file lock so concurrent TT
+    # subprocesses (multiple overlapping STREAM firings) each see a distinct count.
+    cfg_path = os.path.join(
+        os.environ.get("WATERCAM_REPO", "/home/pi/SU-WaterCam"),
+        "runtime_config.json",
+    )
+    new_count = 1
+    auto_shutdown_enabled = True
+    shutdown_limit = 3
+    emergency_mode = False
+
     try:
-        current_count = get_parameter('iteration_count', 0)
-        new_count = current_count + 1
-        set_parameter('iteration_count', new_count)
+        with open(cfg_path, 'r+') as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                cfg = json.load(f)
+            except Exception:
+                cfg = {}
+            current_count = cfg.get('iteration_count', 0)
+            new_count = current_count + 1
+            cfg['iteration_count'] = new_count
+            auto_shutdown_enabled = cfg.get('auto_shutdown_enabled', True)
+            shutdown_limit = cfg.get('shutdown_iteration_limit', 3)
+            emergency_mode = cfg.get('emergency_mode', False)
+            f.seek(0)
+            json.dump(cfg, f, indent=2)
+            f.truncate()
+            fcntl.flock(f, fcntl.LOCK_UN)
         print(f"\n Iteration: {new_count} \n")
     except Exception as e:
         print(f"⚠️ Failed to update iteration count: {e}")
-        new_count = 1
-    
-    # Check if emergency mode is active - if so, ignore shutdown limit
-    try:
-        emergency_mode = get_parameter('emergency_mode', False)
-        if emergency_mode:
-            print(f"🚨 EMERGENCY MODE ACTIVE - Ignoring shutdown limit, continuing data collection")
-            return "emergency_mode_active"
-    except Exception as e:
-        print(f"⚠️ Failed to check emergency mode: {e}")
-    
-    # Use runtime parameter for shutdown limit (only if not in emergency mode)
-    try:
-        shutdown_limit = get_parameter('shutdown_iteration_limit', 3)
-        auto_shutdown_enabled = get_parameter('auto_shutdown_enabled', True)
-        
-        print(f"🔍 Shutdown check: count={new_count}, limit={shutdown_limit}, enabled={auto_shutdown_enabled}")
-        
-        if auto_shutdown_enabled and new_count >= shutdown_limit:
-            print(f"\n🚨 SHUTDOWN TRIGGERED: {new_count} iterations >= {shutdown_limit} limit\n")
-            # using an /etc/doas.conf configured for user pi
-            #call("doas /usr/sbin/shutdown", shell=True) # shutdown Pi
-            print("🔄 Executing sys.exit('shutdown')...")
-            sys.exit("shutdown")
-        else:
-            print(f"✅ Continuing: count={new_count} < limit={shutdown_limit} or shutdown disabled")
-    except Exception as e:
-        print(f"⚠️ Failed to check shutdown parameters: {e}")
-        # Continue without shutdown
-    
+
+    if emergency_mode:
+        print("🚨 EMERGENCY MODE ACTIVE - Ignoring shutdown limit, continuing data collection")
+        return "emergency_mode_active"
+
+    print(f"🔍 Shutdown check: count={new_count}, limit={shutdown_limit}, enabled={auto_shutdown_enabled}")
+
+    if auto_shutdown_enabled and new_count >= shutdown_limit:
+        print(f"\n🚨 SHUTDOWN TRIGGERED: {new_count} iterations >= {shutdown_limit} limit\n")
+        try:
+            # Preferred: graceful OS shutdown via doas (configured in /etc/doas.conf for user pi)
+            call("doas /usr/sbin/shutdown -h now", shell=True)
+        except Exception:
+            pass
+        # Fallback: terminate the TT runtime process
+        sys.exit("shutdown")
+    else:
+        print(f"✅ Continuing: count={new_count} < limit={shutdown_limit} or shutdown disabled")
+
     return "continue"
 
 @SQify
@@ -795,19 +832,39 @@ def flir_planb(dummy):
 @SQify
 def compress_bitmap(segmented_file):
     from tools.compress_segmented import compress_image
-    from tools.lora_runtime_integration import get_parameter
-    print(f"Compressing {segmented_file} for transmission")
-    
-    # Use runtime parameter for compression level
-    
-    
+
+    # Query the mDot's stored payload limit (updated by +TXS: responses).
+    # In raw mode (low budget) the bitmap is the entire payload — use the full
+    # limit.  In tokenized mode the 14-byte TTLoRa header must also fit.
+    # Fall back to 228 B (SF7/500kHz tokenized: 242 − 14).
+    max_bitmap_bytes = 228
     try:
-        bitmap_dict = compress_image(segmented_file)
-        print(f"Completed compressing {segmented_file}")
-        return bitmap_dict['compressed_data'] # this is the byte data
+        from tools.lora_handler_concurrent import get_size_limit
+        lora_limit = get_size_limit()
+        if lora_limit <= _BITMAP_RAW_MODE_THRESHOLD:
+            max_bitmap_bytes = lora_limit          # raw: full budget
+            mode_label = "raw"
+        else:
+            max_bitmap_bytes = lora_limit - 14     # tokenized: leave room for header
+            mode_label = "tokenized"
+        print(f"[compress_bitmap] mDot limit {lora_limit}B → {mode_label} mode, max bitmap {max_bitmap_bytes}B")
+    except Exception as e:
+        print(f"[compress_bitmap] Could not query mDot limit ({e}), using {max_bitmap_bytes}B default")
+
+    if max_bitmap_bytes < 32:
+        print(f"⚠️ [compress_bitmap] mDot limit too small for any bitmap ({max_bitmap_bytes}B after header); skipping")
+        return b''
+
+    print(f"Compressing {segmented_file} for transmission (max {max_bitmap_bytes}B)")
+    try:
+        bitmap_dict = compress_image(segmented_file, max_bytes=max_bitmap_bytes)
+        if not bitmap_dict.get('success'):
+            print(f"⚠️ Could not compress {segmented_file} to fit within {max_bitmap_bytes}B (SF too high?)")
+            return b''
+        print(f"Compressed {segmented_file}: {bitmap_dict['total_size']}B at {bitmap_dict['width']}×{bitmap_dict['height']}px")
+        return bitmap_dict['compressed_data']
     except Exception as e:
         print(f"⚠️ Failed to compress image: {e}")
-        # Return empty bytes as fallback
         return b''
 
 @SQify
@@ -965,22 +1022,40 @@ def lora_token(bitmap):
     except Exception as e:
         print(f"⚠️ Failed to transmit TTToken with sensor data: {e}")
 
+    if not bitmap:
+        print("[lora_token] No bitmap data to transmit")
+        return bitmap
+
     try:
-        token_2 = TTToken(bitmap, time_1, False,
-        TTTag(context, sq_name, 4, recipient_device))
-        lora_msg2 = NetworkInterfaceLoRa.TTLoRaMessage(token_2, recipient_device)
-        encoded_msg2 = lora_msg2.encode_token()
-        packet2 = encoded_msg2.hex()
-        handler.queue_binary_transmit(packet2)
+        _lora_limit_for_bitmap = get_lora_handler().get_size_limit()
+    except Exception:
+        _lora_limit_for_bitmap = 242
+    _use_raw_bitmap_mode = _lora_limit_for_bitmap <= _BITMAP_RAW_MODE_THRESHOLD
 
-        handler.queue_binary_transmit(bitmap)
+    if _use_raw_bitmap_mode:
+        try:
+            handler.queue_binary_transmit(bitmap)
+            print(f"[lora_token] Raw bitmap mode: queued {len(bitmap)}B (mDot limit {_lora_limit_for_bitmap}B)")
+            handler.process_transmit_queue()
+        except Exception as e:
+            print(f"⚠️ Failed to transmit raw bitmap: {e}")
+    else:
+        try:
+            token_2 = TTToken(bitmap, time_1, False,
+            TTTag(context, sq_name, 4, recipient_device))
+            lora_msg2 = NetworkInterfaceLoRa.TTLoRaMessage(token_2, recipient_device)
+            encoded_msg2 = lora_msg2.encode_token()
+            packet2 = encoded_msg2.hex()
+            handler.queue_binary_transmit(packet2)
 
-        print(f" \n Size of Tokenized Bitmap object: {asizeof.asizeof(packet2)} \n")
-        print(f" \n Size of Tokenized Bitmap object getsizeof: {getsizeof(packet2)} \n")
-        handler.process_transmit_queue()
-    except Exception as e:
-        print(f"⚠️ Failed to transmit bitmap: {e}")
-    
+            handler.queue_binary_transmit(bitmap)
+
+            print(f" \n Size of Tokenized Bitmap object: {asizeof.asizeof(packet2)} \n")
+            print(f" \n Size of Tokenized Bitmap object getsizeof: {getsizeof(packet2)} \n")
+            handler.process_transmit_queue()
+        except Exception as e:
+            print(f"⚠️ Failed to transmit bitmap: {e}")
+
     return bitmap
 
 @SQify

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -1783,6 +1783,16 @@ def get_lora_handler() -> LoRaHandler:
             print(f"🔧 LoRaHandler has set_runtime_callback: {hasattr(_lora_handler, 'set_runtime_callback')}")
             print(f"🔧 LoRaHandler has current_size_limit: {hasattr(_lora_handler, 'current_size_limit')}")
             print(f"🔧 LoRaHandler has _is_emergency_message: {hasattr(_lora_handler, '_is_emergency_message')}")
+            # Seed current_size_limit with the actual AT+TXS value BEFORE starting
+            # the listener so there is no response-parsing interference.
+            # Without this, current_size_limit stays at the 242 B default indefinitely
+            # because nothing else sends AT+TXS, and the SF-adaptive bitmap logic
+            # silently behaves as SF7 for the entire session.
+            try:
+                _lora_handler.refresh_size_limit()
+                print(f"🔧 Initial mDot size limit: {_lora_handler.current_size_limit} B")
+            except Exception as txs_err:
+                print(f"⚠️ Could not refresh initial size limit: {txs_err}; using default {_lora_handler.current_size_limit} B")
             _lora_handler.start_listening()
             print("✅ LoRa handler initialized successfully")
         except Exception as e:

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -60,12 +60,11 @@ class LoRaHandler:
         self.listener_thread = None
         self.transmit_lock = threading.Lock()
 
-        # Inter-process UART lock (fcntl.lockf — process-level, POSIX record locks)
-        try:
-            self._lock_fd = open('/var/lock/watercam-lora.lock', 'w')
-        except OSError:
-            import tempfile
-            self._lock_fd = open(os.path.join(tempfile.gettempdir(), 'watercam-lora.lock'), 'w')
+        # Inter-process UART lock (fcntl.lockf — process-level, POSIX record locks).
+        # /tmp is guaranteed writable on all target systems; a single fixed path
+        # ensures every process coordinates on the same lock file regardless of
+        # working directory or user permissions.
+        self._lock_fd = open('/tmp/watercam-lora.lock', 'w')
 
         # Callback for runtime integration
         self.runtime_callback = None

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -60,24 +60,16 @@ class LoRaHandler:
         self.listener_thread = None
         self.transmit_lock = threading.Lock()
 
-        # Inter-process UART lock (fcntl.lockf — process-level, POSIX record locks).
-        # /tmp is guaranteed writable on all target systems; a single fixed path
-        # ensures every process coordinates on the same lock file regardless of
-        # working directory or user permissions.
-        self._lock_fd = open('/tmp/watercam-lora.lock', 'w')
-
         # Callback for runtime integration
         self.runtime_callback = None
-        
+
         # Size limit tracking
         self.current_size_limit = 242  # Default LoRaWAN payload size
-        
+
         # Transmission status tracking
         self.last_transmission_status = None
         self.transmission_history = []
-        
 
-        
         # Configure the serial port
         try:
             self.ser = serial.Serial(
@@ -88,11 +80,11 @@ class LoRaHandler:
                 bytesize=serial.EIGHTBITS,
                 timeout=1
             )
-            
+
             if not self.ser.is_open:
                 print(f"❌ Serial port {port} failed to open")
                 raise RuntimeError(f"Serial port {port} failed to open")
-                
+
         except serial.SerialException as e:
             print(f"❌ Serial port error on {port}: {e}")
             print(f"   Check if device exists and has proper permissions")
@@ -100,6 +92,12 @@ class LoRaHandler:
         except Exception as e:
             print(f"❌ Unexpected error initializing serial port {port}: {e}")
             raise RuntimeError(f"Serial port {port} initialization failed: {e}")
+
+        # Inter-process UART lock (fcntl.lockf — process-level, POSIX record locks).
+        # Opened after serial port succeeds to avoid leaking the FD if init fails.
+        # /tmp is guaranteed writable; single fixed path ensures all processes
+        # coordinate on the same lock file regardless of permissions.
+        self._lock_fd = open('/tmp/watercam-lora.lock', 'w')
     
     def load_config(self) -> Dict[str, Any]:
         """Load configuration from file or create default"""
@@ -1638,35 +1636,38 @@ class LoRaHandler:
                 self.stop_listening()
                 time.sleep(0.5)
             
-            # Hold the inter-process UART lock for the entire AT+TXS exchange so
-            # a concurrent lora_listener process cannot steal the numeric response.
-            fcntl.lockf(self._lock_fd, fcntl.LOCK_EX)
-            try:
-                # Clear buffers and send AT+TXS command
-                self.ser.reset_input_buffer()
-                self.ser.write('AT+TXS\r\n'.encode())
-                time.sleep(1)
+            # Acquire transmit_lock first (intra-process) then fcntl.lockf
+            # (inter-process).  The listener thread holds transmit_lock when it
+            # reads from the serial port, so this prevents it from stealing the
+            # AT+TXS response even if stop_listening() timed out.
+            with self.transmit_lock:
+                fcntl.lockf(self._lock_fd, fcntl.LOCK_EX)
+                try:
+                    # Clear buffers and send AT+TXS command
+                    self.ser.reset_input_buffer()
+                    self.ser.write('AT+TXS\r\n'.encode())
+                    time.sleep(1)
 
-                # Read response directly to get immediate size limit.
-                # _extract_txs_size_limit() handles both "+TXS: 242" and bare "242"
-                # responses — run it on every line so we don't miss the numeric reply.
-                responses = []
-                while self.ser.in_waiting > 0:
-                    res = self.ser.read_until()
-                    if res:
-                        try:
-                            response = res.decode('utf-8').strip()
-                            responses.append(response)
-                            print(f"DEBUG: Manual TXS response: '{response}'")
+                    # Read response directly to get immediate size limit.
+                    # _extract_txs_size_limit() handles both "+TXS: 242" and bare "242"
+                    # responses — run it on every line so we don't miss the numeric reply.
+                    responses = []
+                    while self.ser.in_waiting > 0:
+                        res = self.ser.read_until()
+                        if res:
+                            try:
+                                response = res.decode('utf-8').strip()
+                                responses.append(response)
+                                print(f"DEBUG: Manual TXS response: '{response}'")
 
-                            size_limit = self._extract_txs_size_limit(response)
-                            if size_limit is not None:
-                                self.current_size_limit = size_limit
-                                print(f"DEBUG: Size limit refreshed to: {size_limit} bytes")
-                        except UnicodeDecodeError:
-                            print(f"DEBUG: Binary manual TXS response (hex): {res.hex()}")
-            finally:
-                fcntl.lockf(self._lock_fd, fcntl.LOCK_UN)
+                                size_limit = self._extract_txs_size_limit(response)
+                                if size_limit is not None:
+                                    self.current_size_limit = size_limit
+                                    print(f"DEBUG: Size limit refreshed to: {size_limit} bytes")
+                            except UnicodeDecodeError:
+                                print(f"DEBUG: Binary manual TXS response (hex): {res.hex()}")
+                finally:
+                    fcntl.lockf(self._lock_fd, fcntl.LOCK_UN)
             
             # Re-enable listening if it was active
             if was_listening:

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -59,7 +59,14 @@ class LoRaHandler:
         self.listening = False
         self.listener_thread = None
         self.transmit_lock = threading.Lock()
-        
+
+        # Inter-process UART lock (fcntl.lockf — process-level, POSIX record locks)
+        try:
+            self._lock_fd = open('/var/lock/watercam-lora.lock', 'w')
+        except OSError:
+            import tempfile
+            self._lock_fd = open(os.path.join(tempfile.gettempdir(), 'watercam-lora.lock'), 'w')
+
         # Callback for runtime integration
         self.runtime_callback = None
         
@@ -193,7 +200,11 @@ class LoRaHandler:
                 if self.ser.in_waiting > 0:
                     try:
                         with self.transmit_lock:
-                            raw = self.ser.readline()
+                            fcntl.lockf(self._lock_fd, fcntl.LOCK_EX)
+                            try:
+                                raw = self.ser.readline()
+                            finally:
+                                fcntl.lockf(self._lock_fd, fcntl.LOCK_UN)
                         res = raw.decode().strip()
                         print(f"DEBUG: Raw received: '{res}'")
                         # Skip empty messages
@@ -309,68 +320,54 @@ class LoRaHandler:
     def transmit(self, content: bytes, max_retries: int = 2) -> bool:
         """Transmit data with thread safety and error recovery"""
         with self.transmit_lock:
-            for attempt in range(max_retries + 1):
-                try:
-                    if attempt > 0:
-                        print(f"DEBUG: Retry attempt {attempt}/{max_retries}")
-                        # Clear mDot input on retry
-                        if not self._clear_mdot_input():
-                            print("ERROR: Failed to clear mDot input, aborting retry")
-                            return False
-                    
-                    print(f"DEBUG: Starting transmission of {len(content)} bytes (attempt {attempt + 1})")
-                    print(f"DEBUG: Content to send: {content}")
-                    
-                    # Ensure the serial connection is ready to send
-                    self.ser.flush()
-                    self.ser.reset_input_buffer()
-                    
-                    # Send newline to clear any partial commands
-                    print("DEBUG: Clearing AT interface with newline...")
-                    self.ser.write('\r\n'.encode())
-                    time.sleep(0.5)  # Brief pause to let mDot process
-                    
-                    # Use the stored size limit (updated via listening loop)
-                    size_limit = self.current_size_limit
-                    print(f"DEBUG: Using stored size limit: {size_limit} bytes")
-                    
-                    # Optionally refresh the size limit by sending AT+TXS
-                    print("DEBUG: Sending AT+TXS command to refresh size limit...")
-                    self.ser.write('AT+TXS\r\n'.encode())
-                    
-                    # Brief wait for mDot to process (size limit will be updated via listening loop)
-                    time.sleep(0.5)
-                    
-                    # Attempt transmission
-                    success, error_message = self._attempt_transmission(content, size_limit)
-                    
-                    if success:
-                        return True
-                    else:
-                        print(f"ERROR: Transmission attempt {attempt + 1} failed: {error_message}")
-                        
-                        # If this is not the last attempt, continue to retry
+            # Hold inter-process lock for entire TX sequence so concurrent processes
+            # (e.g. lora_listener subprocess) cannot steal the SENDB response.
+            fcntl.lockf(self._lock_fd, fcntl.LOCK_EX)
+            try:
+                for attempt in range(max_retries + 1):
+                    try:
+                        if attempt > 0:
+                            print(f"DEBUG: Retry attempt {attempt}/{max_retries}")
+                            if not self._clear_mdot_input():
+                                print("ERROR: Failed to clear mDot input, aborting retry")
+                                return False
+
+                        print(f"DEBUG: Starting transmission of {len(content)} bytes (attempt {attempt + 1})")
+                        print(f"DEBUG: Content to send: {content}")
+
+                        # Use the stored size limit (kept current by the listener loop).
+                        # Do NOT send AT+TXS here — it pollutes the RX buffer with "242\r\nOK\r\n"
+                        # that _attempt_transmission() would then misread as the SENDB response.
+                        size_limit = self.current_size_limit
+                        print(f"DEBUG: Using stored size limit: {size_limit} bytes")
+
+                        success, error_message = self._attempt_transmission(content, size_limit)
+
+                        if success:
+                            return True
+                        else:
+                            print(f"ERROR: Transmission attempt {attempt + 1} failed: {error_message}")
+                            if attempt < max_retries:
+                                print(f"DEBUG: Will retry transmission (attempt {attempt + 2}/{max_retries + 1})")
+                                time.sleep(1)
+                                continue
+                            else:
+                                print(f"ERROR: All {max_retries + 1} transmission attempts failed")
+                                return False
+
+                    except Exception as e:
+                        print(f"Error in transmission attempt {attempt + 1}: {e}")
+                        import traceback
+                        traceback.print_exc()
                         if attempt < max_retries:
-                            print(f"DEBUG: Will retry transmission (attempt {attempt + 2}/{max_retries + 1})")
-                            time.sleep(1)  # Brief delay before retry
+                            print(f"DEBUG: Will retry transmission after exception (attempt {attempt + 2}/{max_retries + 1})")
+                            time.sleep(1)
                             continue
                         else:
-                            print(f"ERROR: All {max_retries + 1} transmission attempts failed")
+                            print(f"ERROR: All {max_retries + 1} transmission attempts failed due to exceptions")
                             return False
-                        
-                except Exception as e:
-                    print(f"Error in transmission attempt {attempt + 1}: {e}")
-                    import traceback
-                    traceback.print_exc()
-                    
-                    # If this is not the last attempt, continue to retry
-                    if attempt < max_retries:
-                        print(f"DEBUG: Will retry transmission after exception (attempt {attempt + 2}/{max_retries + 1})")
-                        time.sleep(1)  # Brief delay before retry
-                        continue
-                    else:
-                        print(f"ERROR: All {max_retries + 1} transmission attempts failed due to exceptions")
-                        return False
+            finally:
+                fcntl.lockf(self._lock_fd, fcntl.LOCK_UN)
     
     def queue_transmit(self, data: Dict[str, Any]) -> bool:
         """Queue sensor data for transmission (thread-safe)"""
@@ -1151,6 +1148,10 @@ class LoRaHandler:
         self.stop_listening()
         if self.ser.is_open:
             self.ser.close()
+        try:
+            self._lock_fd.close()
+        except Exception:
+            pass
         print("LoRa handler closed")
     
     def test_reception_format(self, test_payload: str):
@@ -1348,182 +1349,144 @@ class LoRaHandler:
     
     def _attempt_transmission(self, content: bytes, size_limit: int) -> tuple[bool, str]:
         """Attempt a single transmission and return (success, error_message)"""
+
+        def _read_mdot_response(write_deadline_s: float) -> tuple[bool, str, list]:
+            """
+            Poll the serial port until we get OK/ERROR or the deadline expires.
+            Returns (success, error_message, responses).
+
+            Command echoes (lines starting with 'AT') arrive within milliseconds
+            of the write, but the mDot's actual OK/ERROR for AT+SENDB only arrives
+            after the over-air TX completes (typically 3–10 s).  The early-exit
+            idle timer must NOT be started on echo lines — only on real responses.
+            """
+            deadline = time.time() + write_deadline_s
+            final_responses = []
+            success = False
+            error_message = ""
+            got_real_response = False  # True once we see a non-echo line
+            idle_since = None
+
+            while time.time() < deadline:
+                if self.ser.in_waiting > 0:
+                    idle_since = None
+                    try:
+                        res = self.ser.read_until()
+                    except Exception as exc:
+                        print(f"DEBUG: Serial read error: {exc}")
+                        time.sleep(0.1)
+                        continue
+                    if not res:
+                        continue
+                    try:
+                        response = res.decode('utf-8').strip()
+                    except UnicodeDecodeError:
+                        response_hex = res.hex()
+                        final_responses.append(f"BINARY:{response_hex}")
+                        print(f"DEBUG: Binary response (hex): {response_hex}")
+                        if b'OK' in res:
+                            success = True
+                            got_real_response = True
+                            print("DEBUG: mDot confirmed OK (binary)")
+                        elif b'ERROR' in res or b'INVALID' in res:
+                            error_message = f"mDot reported error in binary response: {response_hex}"
+                            got_real_response = True
+                        continue
+
+                    if not response:
+                        continue
+
+                    # Command echoes (the mDot echoing our AT command back) arrive
+                    # quickly but are not terminal responses.  Don't start the
+                    # idle timer on them or we exit before the real OK arrives.
+                    is_cmd_echo = response.upper().startswith('AT')
+                    final_responses.append(response)
+
+                    if is_cmd_echo:
+                        print(f"DEBUG: mDot echo: '{response[:80]}'")
+                    else:
+                        print(f"DEBUG: mDot response: '{response}'")
+                        got_real_response = True
+
+                        if 'OK' in response:
+                            success = True
+                            print("DEBUG: mDot confirmed command execution with OK")
+                        elif 'INVALID COMMAND' in response.upper():
+                            error_message = f"mDot reported invalid command: {response}"
+                            print(f"ERROR: {error_message}")
+                        elif 'INVALID HEX' in response.upper() or 'INVALID STRING' in response.upper():
+                            error_message = f"mDot reported invalid hex string: {response}"
+                            print(f"ERROR: {error_message}")
+                        elif 'ERROR' in response.upper():
+                            error_message = f"mDot reported error: {response}"
+                            print(f"ERROR: {error_message}")
+
+                        # Stop as soon as we have a definitive terminal response
+                        if success or error_message:
+                            break
+                else:
+                    # Only start the idle timer after seeing a real (non-echo) response.
+                    # This avoids premature exit while the mDot is doing its air TX.
+                    if got_real_response:
+                        if idle_since is None:
+                            idle_since = time.time()
+                        elif time.time() - idle_since > 0.5:
+                            break  # 0.5 s of silence after real response → done
+                    time.sleep(0.1)
+
+            return success, error_message, final_responses
+
         try:
-            # Calculate actual payload size and construct AT command
             if isinstance(content, str):
-                # Validate hex string format before sending
                 if not self._is_valid_hex_string(content):
                     return False, f"Invalid hex string format: {content}"
-                
-                # For hex strings, each pair of characters = 1 byte
+
                 payload_size = len(content) // 2
                 print(f"DEBUG: Hex string length: {len(content)} chars, payload size: {payload_size} bytes")
-                
-                if payload_size <= size_limit:
-                    # Construct AT command for hex string
-                    at_command = f"AT+SENDB={content}\r\n".encode()
-                    print(f"DEBUG: Sending AT command: {at_command}")
-                    self.ser.write(at_command)
-                    print("DEBUG: AT command sent, waiting for response...")
-                    
-                    # Wait for response
-                    time.sleep(1)
-                    
-                    # Read response lines and verify success
-                    final_responses = []
-                    success = False
-                    error_message = ""
-                    
-                    while self.ser.in_waiting > 0:
-                        res = self.ser.read_until()
-                        if res:
-                            try:
-                                response = res.decode('utf-8').strip()
-                                final_responses.append(response)
-                                print(f"DEBUG: Final response: '{response}'")
-                                
-                                # Check for OK response and specific error conditions
-                                if 'OK' in response:
-                                    success = True
-                                    print("DEBUG: mDot confirmed command execution with OK")
-                                elif 'INVALID COMMAND' in response.upper():
-                                    error_message = f"mDot reported invalid command: {response}"
-                                    print(f"ERROR: {error_message}")
-                                    print(f"ERROR: Command was: {content}")
-                                elif 'INVALID HEX' in response.upper() or 'INVALID STRING' in response.upper():
-                                    error_message = f"mDot reported invalid hex string: {response}"
-                                    print(f"ERROR: {error_message}")
-                                    print(f"ERROR: Hex string was: {content}")
-                                elif 'ERROR' in response.upper():
-                                    error_message = f"mDot reported error: {response}"
-                                    print(f"ERROR: {error_message}")
-                                    print(f"ERROR: Command was: {content}")
-                            except UnicodeDecodeError:
-                                # Handle binary responses that can't be decoded as UTF-8
-                                response_hex = res.hex()
-                                final_responses.append(f"BINARY:{response_hex}")
-                                print(f"DEBUG: Binary response (hex): {response_hex}")
-                                
-                                # Check if this might be an OK response in binary form
-                                if b'OK' in res:
-                                    success = True
-                                    print("DEBUG: mDot confirmed command execution with OK (binary)")
-                    
-                    # Check if we already have a successful transmission status from the listening loop
-                    if not success and self.last_transmission_status and self.last_transmission_status.get('success', False):
-                        # Only use the status if it's recent (within last 5 seconds)
-                        status_time = self.last_transmission_status.get('timestamp', 0)
-                        if time.time() - status_time < 5:
-                            print("DEBUG: Using successful transmission status from listening loop")
-                            success = True
-                        else:
-                            print("DEBUG: Transmission status too old, ignoring")
-                    
-                    if success:
-                        print("Data sent to mDot successfully!")
-                        return True, ""
-                    else:
-                        if not error_message:
-                            error_message = f"mDot did not respond with OK - responses: {final_responses}"
-                        print(f"ERROR: {error_message}")
-                        return False, error_message
-                else:
-                    error_message = f"Payload size {payload_size} bytes exceeds limit {size_limit} bytes"
-                    print(f'DEBUG: {error_message}')
-                    print('Contents larger than current lora transmission payload')
-                    return False, error_message
+
+                if payload_size > size_limit:
+                    return False, f"Payload size {payload_size} bytes exceeds limit {size_limit} bytes"
+
+                # Discard any stale RX bytes (e.g. leftover echoes from earlier commands)
+                # before sending so they don't pollute our response window.
+                self.ser.reset_input_buffer()
+
+                at_command = f"AT+SENDB={content}\r\n".encode()
+                print(f"DEBUG: Sending AT command: {at_command}")
+                self.ser.write(at_command)
+                print("DEBUG: AT command sent, polling for response (up to 15 s)...")
+
+                success, error_message, final_responses = _read_mdot_response(15)
+
             else:
-                # For bytes, use actual length
                 payload_size = len(content)
                 print(f"DEBUG: Bytes length: {payload_size} bytes")
-                
-                if payload_size <= size_limit:
-                    # Convert bytes to hex string and validate
-                    hex_content = content.hex()
-                    if not self._is_valid_hex_string(hex_content):
-                        return False, f"Generated invalid hex string from bytes: {hex_content}"
-                    
-                    # Write the data to the serial port
-                    print(f"DEBUG: Sending data payload...")
-                    self.ser.write(f'AT+SENDB={hex_content}\r\n'.encode())
-                    print("DEBUG: Data payload sent, waiting for response...")
-                    
-                    # extended wait for response
-                    time.sleep(10)
-                    
-                    # Read response lines and verify success
-                    final_responses = []
-                    success = False
-                    error_message = ""
-                    
-                    while self.ser.in_waiting > 0:
-                        res = self.ser.read_until()
-                        if res:
-                            try:
-                                response = res.decode('utf-8').strip()
-                                final_responses.append(response)
-                                print(f"DEBUG: Final response: '{response}'")
-                                
-                                # Check for OK response and specific error conditions
-                                if 'OK' in response:
-                                    success = True
-                                    print("DEBUG: mDot confirmed command execution with OK")
-                                elif 'INVALID COMMAND' in response.upper():
-                                    error_message = f"mDot reported invalid command: {response}"
-                                    print(f"ERROR: {error_message}")
-                                    print(f"ERROR: Command was: {content}")
-                                elif 'INVALID HEX' in response.upper() or 'INVALID STRING' in response.upper():
-                                    error_message = f"mDot reported invalid hex string: {response}"
-                                    print(f"ERROR: {error_message}")
-                                    print(f"ERROR: Hex string was: {content}")
-                                elif 'ERROR' in response.upper():
-                                    error_message = f"mDot reported error: {response}"
-                                    print(f"ERROR: {error_message}")
-                                    print(f"ERROR: Command was: {content}")
-                            except UnicodeDecodeError:
-                                # Handle binary responses that can't be decoded as UTF-8
-                                response_hex = res.hex()
-                                final_responses.append(f"BINARY:{response_hex}")
-                                print(f"DEBUG: Binary response (hex): {response_hex}")
-                                
-                                # Check if this might be an OK response in binary form
-                                if b'OK' in res:
-                                    success = True
-                                    print("DEBUG: mDot confirmed command execution with OK (binary)")
-                                # Check for error responses in binary form
-                                elif b'ERROR' in res or b'INVALID' in res:
-                                    error_message = f"mDot reported error in binary response: {response_hex}"
-                                    print(f"ERROR: {error_message}")
-                                    print(f"ERROR: Command was: {content}")
-                                # For binary data, check if mDot echoed back the same data (indicates success)
-                                elif res == content:
-                                    success = True
-                                    print("DEBUG: mDot echoed back transmitted data - transmission successful")
-                    
-                    # Check if we already have a successful transmission status from the listening loop
-                    if not success and self.last_transmission_status and self.last_transmission_status.get('success', False):
-                        # Only use the status if it's recent (within last 5 seconds)
-                        status_time = self.last_transmission_status.get('timestamp', 0)
-                        if time.time() - status_time < 5:
-                            print("DEBUG: Using successful transmission status from listening loop")
-                            success = True
-                        else:
-                            print("DEBUG: Transmission status too old, ignoring")
-                    
-                    if success:
-                        print("Data sent to mDot successfully!")
-                        return True, ""
-                    else:
-                        if not error_message:
-                            error_message = f"mDot did not respond with OK - responses: {final_responses}"
-                        print(f"ERROR: {error_message}")
-                        return False, error_message
-                else:
-                    error_message = f"Payload size {payload_size} bytes exceeds limit {size_limit} bytes"
-                    print(f'DEBUG: {error_message}')
-                    print('Contents larger than current lora transmission payload')
-                    return False, error_message
-                    
+
+                if payload_size > size_limit:
+                    return False, f"Payload size {payload_size} bytes exceeds limit {size_limit} bytes"
+
+                hex_content = content.hex()
+                if not self._is_valid_hex_string(hex_content):
+                    return False, f"Generated invalid hex string from bytes: {hex_content}"
+
+                # Discard stale RX bytes before sending
+                self.ser.reset_input_buffer()
+
+                print(f"DEBUG: Sending data payload...")
+                self.ser.write(f'AT+SENDB={hex_content}\r\n'.encode())
+                print("DEBUG: Data payload sent, polling for response (up to 20 s)...")
+
+                success, error_message, final_responses = _read_mdot_response(20)
+
+            if success:
+                print("Data sent to mDot successfully!")
+                return True, ""
+            else:
+                if not error_message:
+                    error_message = f"mDot did not respond with OK - responses: {final_responses}"
+                print(f"ERROR: {error_message}")
+                return False, error_message
+
         except Exception as e:
             error_message = f"Exception during transmission: {e}"
             print(f"Error sending to mDot: {e}")

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -95,9 +95,13 @@ class LoRaHandler:
 
         # Inter-process UART lock (fcntl.lockf — process-level, POSIX record locks).
         # Opened after serial port succeeds to avoid leaking the FD if init fails.
-        # /tmp is guaranteed writable; single fixed path ensures all processes
-        # coordinate on the same lock file regardless of permissions.
-        self._lock_fd = open('/tmp/watercam-lora.lock', 'w')
+        # /run/lock is the standard runtime lock directory (tmpfs, cleared on reboot).
+        # os.open with mode 0o600 creates the file with owner-only permissions,
+        # preventing symlink/hardlink attacks possible with world-writable /tmp.
+        _lock_path = '/run/lock/watercam-lora.lock'
+        self._lock_fd = os.fdopen(
+            os.open(_lock_path, os.O_CREAT | os.O_WRONLY, 0o600), 'w'
+        )
     
     def load_config(self) -> Dict[str, Any]:
         """Load configuration from file or create default"""

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -1639,30 +1639,35 @@ class LoRaHandler:
                 self.stop_listening()
                 time.sleep(0.5)
             
-            # Clear buffers and send AT+TXS command
-            self.ser.reset_input_buffer()
-            self.ser.write('AT+TXS\r\n'.encode())
-            time.sleep(1)
-            
-            # Read response directly to get immediate size limit
-            responses = []
-            while self.ser.in_waiting > 0:
-                res = self.ser.read_until()
-                if res:
-                    try:
-                        response = res.decode('utf-8').strip()
-                        responses.append(response)
-                        print(f"DEBUG: Manual TXS response: '{response}'")
-                        
-                        # Check if this is a +TXS: response
-                        if "+TXS:" in response.upper():
+            # Hold the inter-process UART lock for the entire AT+TXS exchange so
+            # a concurrent lora_listener process cannot steal the numeric response.
+            fcntl.lockf(self._lock_fd, fcntl.LOCK_EX)
+            try:
+                # Clear buffers and send AT+TXS command
+                self.ser.reset_input_buffer()
+                self.ser.write('AT+TXS\r\n'.encode())
+                time.sleep(1)
+
+                # Read response directly to get immediate size limit.
+                # _extract_txs_size_limit() handles both "+TXS: 242" and bare "242"
+                # responses — run it on every line so we don't miss the numeric reply.
+                responses = []
+                while self.ser.in_waiting > 0:
+                    res = self.ser.read_until()
+                    if res:
+                        try:
+                            response = res.decode('utf-8').strip()
+                            responses.append(response)
+                            print(f"DEBUG: Manual TXS response: '{response}'")
+
                             size_limit = self._extract_txs_size_limit(response)
                             if size_limit is not None:
                                 self.current_size_limit = size_limit
                                 print(f"DEBUG: Size limit refreshed to: {size_limit} bytes")
-                    except UnicodeDecodeError:
-                        response_hex = res.hex()
-                        print(f"DEBUG: Binary manual TXS response (hex): {response_hex}")
+                        except UnicodeDecodeError:
+                            print(f"DEBUG: Binary manual TXS response (hex): {res.hex()}")
+            finally:
+                fcntl.lockf(self._lock_fd, fcntl.LOCK_UN)
             
             # Re-enable listening if it was active
             if was_listening:

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -18,6 +18,7 @@ Usage:
     # Parameters are automatically updated when LoRa commands are received
 """
 
+import fcntl
 import json
 import math
 import os
@@ -169,8 +170,20 @@ class LoRaRuntimeManager:
     def save_parameters(self, params: Dict[str, Any]) -> bool:
         """Save runtime parameters to file. Returns True on success, False on failure."""
         try:
-            with open(self.config_file, 'w') as f:
-                json.dump(params, f, indent=2)
+            # Use the same flock + seek/truncate pattern as call_shutdown() so all
+            # writers coordinate on runtime_config.json and don't interleave.
+            try:
+                f = open(self.config_file, 'r+')
+            except FileNotFoundError:
+                f = open(self.config_file, 'w')
+            with f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                try:
+                    f.seek(0)
+                    json.dump(params, f, indent=2)
+                    f.truncate()
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
             return True
         except Exception as e:
             print(f"Error saving runtime config: {e}")

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -154,7 +154,11 @@ class LoRaRuntimeManager:
         if os.path.exists(self.config_file):
             try:
                 with open(self.config_file, 'r') as f:
-                    loaded_params = json.load(f)
+                    fcntl.flock(f, fcntl.LOCK_SH)
+                    try:
+                        loaded_params = json.load(f)
+                    finally:
+                        fcntl.flock(f, fcntl.LOCK_UN)
                     # Merge with defaults to ensure all parameters exist
                     for key, value in default_params.items():
                         if key not in loaded_params:
@@ -170,13 +174,12 @@ class LoRaRuntimeManager:
     def save_parameters(self, params: Dict[str, Any]) -> bool:
         """Save runtime parameters to file. Returns True on success, False on failure."""
         try:
-            # Use the same flock + seek/truncate pattern as call_shutdown() so all
-            # writers coordinate on runtime_config.json and don't interleave.
-            try:
-                f = open(self.config_file, 'r+')
-            except FileNotFoundError:
-                f = open(self.config_file, 'w')
-            with f:
+            # os.open with O_CREAT|O_RDWR opens or creates the file without
+            # truncating it, so the lock is acquired before any data is lost.
+            # Opening with 'w' would truncate before flock, exposing an empty
+            # file to concurrent readers.
+            fd = os.open(self.config_file, os.O_CREAT | os.O_RDWR, 0o600)
+            with os.fdopen(fd, 'r+') as f:
                 fcntl.flock(f, fcntl.LOCK_EX)
                 try:
                     f.seek(0)

--- a/tools/lora_runtime_integration.py
+++ b/tools/lora_runtime_integration.py
@@ -192,6 +192,35 @@ class LoRaRuntimeManager:
             print(f"Error saving runtime config: {e}")
             return False
     
+    def atomic_increment_iteration_count(self) -> dict:
+        """Atomically increment iteration_count; return shutdown control fields.
+
+        Uses os.open(O_CREAT|O_RDWR) so the file is created if absent, flock
+        for mutual exclusion with all other writers, and updates the in-memory
+        cache so subsequent set_parameter()/save_parameters() calls don't
+        overwrite the new count with a stale cached value.
+        """
+        fd = os.open(self.config_file, os.O_CREAT | os.O_RDWR, 0o600)
+        with os.fdopen(fd, 'r+') as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                content = f.read()
+                cfg = json.loads(content) if content.strip() else {}
+                new_count = cfg.get('iteration_count', 0) + 1
+                cfg['iteration_count'] = new_count
+                self.parameters['iteration_count'] = new_count  # keep cache consistent
+                f.seek(0)
+                json.dump(cfg, f, indent=2)
+                f.truncate()
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+        return {
+            'iteration_count': new_count,
+            'auto_shutdown_enabled': cfg.get('auto_shutdown_enabled', True),
+            'shutdown_iteration_limit': cfg.get('shutdown_iteration_limit', 3),
+            'emergency_mode': cfg.get('emergency_mode', False),
+        }
+
     def get_parameter(self, key: str, default: Any = None) -> Any:
         """Get a runtime parameter value"""
         return self.parameters.get(key, default)


### PR DESCRIPTION
## Summary

- **`ticktalk_main.py`**: `compress_bitmap()` now queries the mDot's stored payload limit (`get_size_limit()`) before calling `compress_image()`, so the binary-search compression targets the actual SF budget instead of a hardcoded 228 B. When budget is ≤128 B (SF8+), enters **raw mode**: bitmaps sent as bare bytes (no TTLoRa header), gaining 14 bytes for image data. `lora_token()` / `lora_token_with_tracker()` use the same threshold to skip TTToken wrapping in raw mode.
- **`tools/lora_handler_concurrent.py`**: Add inter-process UART lock (`fcntl.lockf`) so concurrent processes cannot race on the mDot serial port. Refactor `transmit()` to hold the lock for the entire TX sequence.
- **`docs/BITMAP_SF_ADAPTIVE_COMPRESSION.md`**: Documents root cause, SF payload table, mode decision logic, and cross-references companion API PR.

## Root cause

`compress_bitmap()` hardcoded `max_bytes=228` (SF7 budget). At SF8+ the gateway silently truncated the payload — the Brotli stream arrived without its end-of-stream marker, causing `Unexpected EOF` on the server. The `LoRaHandler` already tracked `current_size_limit` and `_attempt_transmission()` enforced it, but by then the bitmap was already sized wrong. If `current_size_limit` was still at its default of 242 B (no `+TXS:` response yet), the check passed and the mDot sent an oversized packet.

## Payload budgets after fix

| SF (US915) | Limit | Mode | Bitmap budget |
|---|---|---|---|
| SF7 / 500 kHz | 242 B | tokenized | 228 B |
| SF7 / 125 kHz | 133 B | tokenized | 119 B |
| SF8 / 500 kHz | 125 B | **raw** | 125 B |
| SF8 / 125 kHz | 61 B | **raw** | 61 B |
| SF9 | 53 B | **raw** | 53 B |

## Test plan

- [ ] At SF7: verify `_BITMAP_RAW_MODE_THRESHOLD` check routes to tokenized path; bitmap ≤228 B; TTToken + raw both transmitted
- [ ] At SF8 (mock `get_size_limit()` → 125): verify raw mode selected; bitmap ≤125 B; only bare bytes transmitted
- [ ] Verify server stores raw-mode bitmaps correctly via raw bitmap detection path in API
- [ ] Verify `compress_image(success=False)` case: `compress_bitmap()` returns `b''`, `lora_token()` skips transmission gracefully
- [ ] Verify empty bitmap guard: `lora_token(b'')` returns immediately without queuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)