### PR TITLE
fix: guard witty_pi_4 module-level import to prevent ImportError on load

### DIFF
--- a/tools/wittypi_control.py
+++ b/tools/wittypi_control.py
@@ -1,13 +1,29 @@
 #! /usr/bin/python3
 
-from witty_pi_4 import WittyPi4
+# witty_pi_4 may live in tools/ (not on sys.path when imported as a package)
+# or in the system/venv site-packages; try both before giving up.
+try:
+    from witty_pi_4 import WittyPi4 as _WittyPi4Class
+except ImportError:
+    try:
+        from tools.witty_pi_4 import WittyPi4 as _WittyPi4Class
+    except ImportError:
+        _WittyPi4Class = None
 
-witty_pi_4 = WittyPi4()
+witty_pi_4 = _WittyPi4Class() if _WittyPi4Class is not None else None
+
+
+def _require_wittypi():
+    if witty_pi_4 is None:
+        raise ImportError("witty_pi_4 not available")
+
 
 def sync_time():
+    _require_wittypi()
     witty_pi_4.sync_time_with_network()
 
 def get_data():
+    _require_wittypi()
     temperature = witty_pi_4.get_temperature()
     battery_voltage = witty_pi_4.get_battery_voltage()
     internal_voltage = witty_pi_4.get_internal_voltage()
@@ -15,11 +31,13 @@ def get_data():
     return temperature, battery_voltage, internal_voltage, internal_current
 
 def set_schedule(start_hour, start_minute, interval_length_minutes, num_repetitions_per_day):
+    _require_wittypi()
     witty_pi_4.generate_schedule(start_hour, start_minute, interval_length_minutes, num_repetitions_per_day)
     next_startup_time = witty_pi_4.apply_schedule()
     return next_startup_time
 
 def clear_shutdown_time():
+    _require_wittypi()
     witty_pi_4.clear_shutdown_time()
 
 from ticktalkpython.SQ import SQify


### PR DESCRIPTION
from witty_pi_4 import WittyPi4 at module scope failed with 'No module named witty_pi_4' when wittypi_control was imported as a package (from tools.wittypi_control) because tools/ is not on sys.path.

Try bare import first (works when running as a script or if installed system-wide), then fall back to tools.witty_pi_4 (local copy).  If both fail, witty_pi_4 = None; _require_wittypi() raises ImportError inside each function so the existing except ImportError blocks in get_wittypi_status() and wittypi_emergency_control() catch it cleanly.