### PR TITLE
fix(lora): thread-safe singleton, clean partial-init, narrow listener OK match

### DIFF
--- a/tests/test_singleton_and_filtering.py
+++ b/tests/test_singleton_and_filtering.py
@@ -1,0 +1,160 @@
+"""Regression tests for the LoRa handler singleton and listener classification fixes.
+
+Covers two areas flagged in Copilot review of PR #81:
+
+1. get_lora_handler() thread-safety — N concurrent callers must produce exactly
+   one LoRaHandler instance and the global must not be published until after
+   refresh_size_limit() and start_listening() both complete.
+
+2. _is_transmission_response() classification — bare 'OK'/'ERROR' must not match
+   (they are AT echo responses, not TX outcomes); real TX status patterns must.
+
+Hardware is provided by the autouse _mock_serial_port fixture in conftest.py.
+"""
+import threading
+from unittest.mock import patch, MagicMock
+import pytest
+
+import tools.lora_handler_concurrent as lhc
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Clear the module-level singleton before and after every test in this file."""
+    lhc._lora_handler = None
+    yield
+    lhc._lora_handler = None
+
+
+@pytest.fixture
+def handler():
+    """Bare LoRaHandler instance — serial patched by conftest, no listener started."""
+    return lhc.LoRaHandler()
+
+
+# ---------------------------------------------------------------------------
+# Singleton thread-safety
+# ---------------------------------------------------------------------------
+
+class TestGetLoraHandlerSingleton:
+
+    def test_single_construction_under_concurrency(self):
+        """20 concurrent threads calling get_lora_handler() must build one instance."""
+        n = 20
+        barrier = threading.Barrier(n)
+        results = []
+        errors = []
+
+        with patch.object(lhc.LoRaHandler, 'refresh_size_limit', autospec=True, return_value=True), \
+             patch.object(lhc.LoRaHandler, 'start_listening', autospec=True):
+
+            def _call():
+                try:
+                    barrier.wait()
+                    results.append(lhc.get_lora_handler())
+                except Exception as exc:
+                    errors.append(exc)
+
+            threads = [threading.Thread(target=_call) for _ in range(n)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert not errors, f"Thread(s) raised: {errors}"
+        assert len(results) == n
+        # Every caller must receive the identical object.
+        assert all(r is results[0] for r in results), (
+            f"Got {len({id(r) for r in results})} distinct instances, expected 1"
+        )
+
+    def test_global_published_only_after_full_init(self):
+        """_lora_handler must stay None while refresh_size_limit and start_listening run.
+
+        This guards against the race where a fast-path caller on another thread
+        receives a partially-initialised handler because the global was written
+        before start_listening() returned.
+        """
+        lora_during_refresh = [object()]  # sentinel — must be replaced
+        lora_during_start = [object()]
+
+        def capture_refresh(self_):
+            lora_during_refresh[0] = lhc._lora_handler
+
+        def capture_start(self_):
+            lora_during_start[0] = lhc._lora_handler
+
+        with patch.object(lhc.LoRaHandler, 'refresh_size_limit', autospec=True,
+                          side_effect=capture_refresh), \
+             patch.object(lhc.LoRaHandler, 'start_listening', autospec=True,
+                          side_effect=capture_start):
+            handler = lhc.get_lora_handler()
+
+        assert lora_during_refresh[0] is None, (
+            "_lora_handler was set before refresh_size_limit() returned"
+        )
+        assert lora_during_start[0] is None, (
+            "_lora_handler was set before start_listening() returned"
+        )
+        assert lhc._lora_handler is handler
+
+    def test_second_call_returns_same_instance(self):
+        """Calling get_lora_handler() twice returns the cached singleton."""
+        with patch.object(lhc.LoRaHandler, 'refresh_size_limit', autospec=True, return_value=True), \
+             patch.object(lhc.LoRaHandler, 'start_listening', autospec=True):
+            h1 = lhc.get_lora_handler()
+            h2 = lhc.get_lora_handler()
+
+        assert h1 is h2
+
+
+# ---------------------------------------------------------------------------
+# _is_transmission_response classification
+# ---------------------------------------------------------------------------
+
+class TestTransmissionResponseClassification:
+    """
+    After removing bare 'OK'/'ERROR' from _is_transmission_response(), those
+    strings must fall through to _is_at_response() (which returns True via its
+    final fallback) rather than being logged as transmission successes.
+    """
+
+    # Bare AT echoes — must NOT be treated as TX responses.
+    @pytest.mark.parametrize("msg", ["OK", "ERROR", "ok", "error", "Ok", "Error"])
+    def test_bare_at_responses_are_not_tx_responses(self, handler, msg):
+        assert not handler._is_transmission_response(msg), (
+            f"'{msg}' should not match _is_transmission_response "
+            "(it is an AT echo, not a TX outcome)"
+        )
+
+    # Real mDot TX status lines — must match.
+    @pytest.mark.parametrize("msg", [
+        "SENDB: 0",
+        "SEND: ok",
+        "TX: complete",
+        "TRANSMIT: done",
+        "PACKET: info",
+        "PAYLOAD: 42",
+        "TRANSMITTED",
+        "SENT",
+        "DELIVERED",
+        "ACK received",
+    ])
+    def test_real_tx_patterns_are_tx_responses(self, handler, msg):
+        assert handler._is_transmission_response(msg), (
+            f"'{msg}' should match _is_transmission_response"
+        )
+
+    def test_ok_falls_through_to_at_response(self, handler):
+        """'OK' must be classified as an AT response (ignored), not a TX response."""
+        assert not handler._is_transmission_response("OK")
+        assert handler._is_at_response("OK")
+
+    def test_error_falls_through_to_at_response(self, handler):
+        """'ERROR' must be classified as an AT response (ignored), not a TX response."""
+        assert not handler._is_transmission_response("ERROR")
+        assert handler._is_at_response("ERROR")

--- a/tests/test_singleton_and_filtering.py
+++ b/tests/test_singleton_and_filtering.py
@@ -12,7 +12,7 @@ Covers two areas flagged in Copilot review of PR #81:
 Hardware is provided by the autouse _mock_serial_port fixture in conftest.py.
 """
 import threading
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import pytest
 
 import tools.lora_handler_concurrent as lhc
@@ -45,7 +45,8 @@ class TestGetLoraHandlerSingleton:
     def test_single_construction_under_concurrency(self):
         """20 concurrent threads calling get_lora_handler() must build one instance."""
         n = 20
-        barrier = threading.Barrier(n)
+        # Timeout on barrier.wait() so a deadlock fails the test instead of hanging CI.
+        barrier = threading.Barrier(n, timeout=5)
         results = []
         errors = []
 
@@ -63,8 +64,11 @@ class TestGetLoraHandlerSingleton:
             for t in threads:
                 t.start()
             for t in threads:
-                t.join()
+                t.join(timeout=10)
 
+        # Fail fast if any thread is still alive (deadlock / hang).
+        hung = [t for t in threads if t.is_alive()]
+        assert not hung, f"{len(hung)} thread(s) did not finish within timeout"
         assert not errors, f"Thread(s) raised: {errors}"
         assert len(results) == n
         # Every caller must receive the identical object.

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -1837,6 +1837,7 @@ def get_lora_handler() -> LoRaHandler:
             _lora_handler = handler  # publish only after full init
             print("✅ LoRa handler initialized successfully")
         except Exception as e:
+            _lora_handler = None  # explicit: global was never written, but make intent clear
             print(f"❌ Failed to initialize LoRa handler: {e}")
             print("⚠️ LoRa functionality will not be available")
             raise RuntimeError(f"LoRa handler initialization failed: {e}") from e

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -1811,45 +1811,35 @@ def get_lora_handler() -> LoRaHandler:
     """Get the global LoRa handler instance (thread-safe singleton)."""
     global _lora_handler
     if _lora_handler is not None:
-        print(f"🔧 Returning existing LoRaHandler: {type(_lora_handler)}")
-        print(f"🔧 LoRaHandler methods: {[method for method in dir(_lora_handler) if not method.startswith('_')]}")
-        print(f"🔧 LoRaHandler has set_runtime_callback: {hasattr(_lora_handler, 'set_runtime_callback')}")
         return _lora_handler
     with _lora_handler_lock:
         # Re-check inside the lock — another thread may have created it while we waited.
         if _lora_handler is not None:
-            print(f"🔧 Returning existing LoRaHandler: {type(_lora_handler)}")
-            print(f"🔧 LoRaHandler methods: {[method for method in dir(_lora_handler) if not method.startswith('_')]}")
-            print(f"🔧 LoRaHandler has set_runtime_callback: {hasattr(_lora_handler, 'set_runtime_callback')}")
             return _lora_handler
         try:
-            print(f"🔧 Creating new LoRaHandler instance...")
-            _lora_handler = LoRaHandler()
-            print(f"🔧 LoRaHandler created: {type(_lora_handler)}")
-            print(f"🔧 LoRaHandler class: {_lora_handler.__class__}")
-            print(f"🔧 LoRaHandler module: {_lora_handler.__class__.__module__}")
-            print(f"🔧 LoRaHandler methods: {[method for method in dir(_lora_handler) if not method.startswith('_')]}")
-            print(f"🔧 LoRaHandler has set_runtime_callback: {hasattr(_lora_handler, 'set_runtime_callback')}")
-            print(f"🔧 LoRaHandler has current_size_limit: {hasattr(_lora_handler, 'current_size_limit')}")
-            print(f"🔧 LoRaHandler has _is_emergency_message: {hasattr(_lora_handler, '_is_emergency_message')}")
+            print("🔧 Creating new LoRaHandler instance...")
+            # Build in a local variable so the global is only written once
+            # initialization is fully complete.  Any thread hitting the outer
+            # fast-path before this point sees None and will block on the lock,
+            # then pick up the fully-ready instance from the inner re-check.
+            handler = LoRaHandler()
             # Seed current_size_limit with the actual AT+TXS value BEFORE starting
             # the listener so there is no response-parsing interference.
             # Without this, current_size_limit stays at the 242 B default indefinitely
             # because nothing else sends AT+TXS, and the SF-adaptive bitmap logic
             # silently behaves as SF7 for the entire session.
             try:
-                _lora_handler.refresh_size_limit()
-                print(f"🔧 Initial mDot size limit: {_lora_handler.current_size_limit} B")
+                handler.refresh_size_limit()
+                print(f"🔧 Initial mDot size limit: {handler.current_size_limit} B")
             except Exception as txs_err:
-                print(f"⚠️ Could not refresh initial size limit: {txs_err}; using default {_lora_handler.current_size_limit} B")
-            _lora_handler.start_listening()
+                print(f"⚠️ Could not refresh initial size limit: {txs_err}; using default {handler.current_size_limit} B")
+            handler.start_listening()
+            _lora_handler = handler  # publish only after full init
             print("✅ LoRa handler initialized successfully")
         except Exception as e:
-            _lora_handler = None  # don't return a partially-initialized instance
             print(f"❌ Failed to initialize LoRa handler: {e}")
             print("⚠️ LoRa functionality will not be available")
-            # Don't create a mock handler - let the error propagate
-            raise RuntimeError(f"LoRa handler initialization failed: {e}")
+            raise RuntimeError(f"LoRa handler initialization failed: {e}") from e
     return _lora_handler
 
 def transmit_data(data: Dict[str, Any]) -> bool:

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -1525,10 +1525,6 @@ class LoRaHandler:
         if any(keyword in message_upper for keyword in ['TRANSMITTED', 'SENT', 'DELIVERED', 'ACK']):
             return True
         
-        # Check for standard AT command responses that indicate success/failure
-        if any(keyword in message_upper for keyword in ['OK', 'ERROR']):
-            return True
-            
         return False
     
     def _extract_txs_size_limit(self, message: str) -> int:
@@ -1809,11 +1805,23 @@ class LoRaHandler:
 
 # Global instance for easy access from other modules
 _lora_handler = None
+_lora_handler_lock = threading.Lock()
 
 def get_lora_handler() -> LoRaHandler:
-    """Get the global LoRa handler instance"""
+    """Get the global LoRa handler instance (thread-safe singleton)."""
     global _lora_handler
-    if _lora_handler is None:
+    if _lora_handler is not None:
+        print(f"🔧 Returning existing LoRaHandler: {type(_lora_handler)}")
+        print(f"🔧 LoRaHandler methods: {[method for method in dir(_lora_handler) if not method.startswith('_')]}")
+        print(f"🔧 LoRaHandler has set_runtime_callback: {hasattr(_lora_handler, 'set_runtime_callback')}")
+        return _lora_handler
+    with _lora_handler_lock:
+        # Re-check inside the lock — another thread may have created it while we waited.
+        if _lora_handler is not None:
+            print(f"🔧 Returning existing LoRaHandler: {type(_lora_handler)}")
+            print(f"🔧 LoRaHandler methods: {[method for method in dir(_lora_handler) if not method.startswith('_')]}")
+            print(f"🔧 LoRaHandler has set_runtime_callback: {hasattr(_lora_handler, 'set_runtime_callback')}")
+            return _lora_handler
         try:
             print(f"🔧 Creating new LoRaHandler instance...")
             _lora_handler = LoRaHandler()
@@ -1837,14 +1845,11 @@ def get_lora_handler() -> LoRaHandler:
             _lora_handler.start_listening()
             print("✅ LoRa handler initialized successfully")
         except Exception as e:
+            _lora_handler = None  # don't return a partially-initialized instance
             print(f"❌ Failed to initialize LoRa handler: {e}")
             print("⚠️ LoRa functionality will not be available")
             # Don't create a mock handler - let the error propagate
             raise RuntimeError(f"LoRa handler initialization failed: {e}")
-    else:
-        print(f"🔧 Returning existing LoRaHandler: {type(_lora_handler)}")
-        print(f"🔧 LoRaHandler methods: {[method for method in dir(_lora_handler) if not method.startswith('_')]}")
-        print(f"🔧 LoRaHandler has set_runtime_callback: {hasattr(_lora_handler, 'set_runtime_callback')}")
     return _lora_handler
 
 def transmit_data(data: Dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary

Fixes three bugs observed in production logs from `ufo-01-01-007` on 2026-05-31, where all LoRa transmissions failed every cycle and the mDot size limit was read as 24 B instead of the correct 241 B.

- **Singleton race condition** — multiple threads created separate `LoRaHandler` instances at startup, raced on the serial port during `AT+TXS`, and corrupted the cached payload size limit from 241 B to 24 B, causing every transmission to fail the pre-send size check
- **Partial-init instance stored on error** — `_lora_handler` was assigned before `start_listening()` completed; a mid-init exception left a broken instance in the module global, returned to all future callers
- **Listener falsely logged "Transmission success: OK"** — `_is_transmission_response()` matched bare `'OK'`/`'ERROR'`, so the listener treated buffer-clearing AT responses as successful LoRa uplinks and polluted `transmission_history`

## Root cause chain

TTPython catch-up frames run multiple SQs concurrently. All of them call `get_lora_handler()` before any one finishes creating the instance, because the `if _lora_handler is None` check had no mutex. Three instances were created, each called `refresh_size_limit()` simultaneously. `fcntl.lockf` is per-process — within one process it is non-blocking even with separate fds on the same file — so all three entered the `AT+TXS` critical section at once. Interleaved serial reads produced `'24'` instead of `'241'`. The corrupted limit was cached as the singleton's value, and every bitmap and sensor packet (45–59 B) was rejected before the mDot was ever contacted.

## Changes

| | Fix |
|---|---|
| **Bug 1** | Double-checked locking with `_lora_handler_lock = threading.Lock()` — fast outer check (no lock) for the already-initialized path; inner re-check after acquiring the lock ensures only one thread creates the instance |
| **Bug 2** | `_lora_handler = None` in the `except` block so a failed init doesn't leave a broken instance for future callers |
| **Bug 3** | Removed bare `'OK'`/`'ERROR'` from `_is_transmission_response()`; they fall through to `_is_at_response()` which ignores them |

## Test plan

- [ ] Deploy to `ufo-01-01-007`, restart `ticktalk`, confirm only one `🔧 Creating new LoRaHandler instance...` line appears in `journalctl`
- [ ] Confirm size limit is logged as 241 B (not 24 B) after init
- [ ] Confirm sensor and bitmap transmissions succeed in subsequent cycles
- [ ] Confirm no false `✅ Transmission success: OK` entries appear during retry sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)