### PR TITLE
feat(lora): store-and-forward queue for LoRa transmissions

### DIFF
--- a/ticktalk_main.py
+++ b/ticktalk_main.py
@@ -205,12 +205,14 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
     """
     Enhanced LoRa transmission function that uses sensor tracker to only transmit changed values
     """
+    import time as _time
     from ticktalkpython.Clock import TTClock
     from ticktalkpython.TTToken import TTToken
     from ticktalkpython.Time import TTTime
     import pickle
 
     from tools.lora_handler_concurrent import get_lora_handler, get_config_value, transmit_data, transmit_binary, compressed_encoding
+    from tools import lora_store_forward as _lsf
 
     from ticktalkpython.Tag import TTTag
     from ticktalkpython import NetworkInterfaceLoRa
@@ -221,6 +223,7 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
     # Helper functions are now imported at module level
 
     # LoRa transmission is always enabled
+    captured_at = _time.time()
 
     root_clock = TTClock.root()
     # Create a time-tagged token using that interval and the derived clock
@@ -289,6 +292,10 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
         'neighborhood_emergency_frequency': get_parameter('neighborhood_emergency_frequency', 30)
     })
 
+    # Embed capture timestamp so stored packets carry original collection time
+    if 'timestamp' not in data:
+        data['timestamp'] = int(captured_at)
+
     # Check sensor changes using tracker if available (unless always_transmit_sensors is set)
     always_transmit_sensors = get_parameter('always_transmit_sensors', False)
     if always_transmit_sensors:
@@ -319,6 +326,37 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
         handler = get_lora_handler()
     except Exception as e:
         print(f"⚠️ Failed to get LoRa handler: {e}")
+        return bitmap
+
+    # Store-and-forward: if the mDot is not joined, queue the payloads and skip
+    # transmission.  The mDot will rejoin autonomously; the next cycle drains the
+    # backlog (trickle: 2 packets/cycle) after sending the current data first.
+    _sf_enabled = get_config_value('lora_sf_enabled', True)
+    if _sf_enabled and not handler.is_joined():
+        _sensor_hex = None
+        _bitmap_hex = None
+        try:
+            # Always include 'timestamp' even when tracker filtering is active —
+            # the sensor tracker explicitly excludes it from sensors_to_transmit,
+            # but it must be in every stored packet so the gateway sees capture time.
+            _sf_data = ({k: v for k, v in data.items()
+                         if k in sensors_to_transmit or k == 'timestamp'}
+                        if (sensor_tracker and sensors_to_transmit) else data)
+            if always_transmit_sensors or not sensor_tracker or sensors_to_transmit:
+                _sensor_hex = handler.compressed_encoding(_sf_data).hex()
+        except Exception as _e:
+            print(f"⚠️ S&F: sensor encode failed: {_e}")
+        try:
+            if bitmap:
+                _bitmap_hex = handler.compressed_encoding({'flood_bitmap_compressed': bitmap}).hex()
+        except Exception as _e:
+            print(f"⚠️ S&F: bitmap encode failed: {_e}")
+        _lsf.enqueue(
+            _sensor_hex, _bitmap_hex, captured_at,
+            max_depth=get_config_value('lora_sf_max_depth', 96),
+            max_age_days=get_config_value('lora_sf_max_age_days', 7),
+        )
+        print(f"📦 LoRa not joined — data queued (depth: {_lsf.queue_depth()})")
         return bitmap
 
     # Transmit sensor data if: no tracker, always_transmit_sensors, or changes detected
@@ -409,6 +447,21 @@ def lora_token_with_tracker(bitmap, sensor_tracker):
             handler.process_transmit_queue()
         except Exception as e:
             print(f"⚠️ Failed to transmit bitmap: {e}")
+
+    # Store-and-forward: trickle-drain backlog after current data is sent
+    if _sf_enabled:
+        try:
+            _drain = _lsf.drain(
+                handler,
+                max_packets=get_config_value('lora_sf_drain_per_cycle', 2),
+                max_age_days=get_config_value('lora_sf_max_age_days', 7),
+            )
+            if _drain['drained']:
+                print(f"📤 S&F: drained {_drain['drained']} queued packet(s)")
+            if _drain['failed']:
+                print(f"⚠️ S&F: drain stopped early (transmission failure)")
+        except Exception as _e:
+            print(f"⚠️ S&F: drain error: {_e}")
 
     # Update sensor tracker with transmission results
     if sensor_tracker:

--- a/tools/lora_handler_concurrent.py
+++ b/tools/lora_handler_concurrent.py
@@ -135,7 +135,11 @@ class LoRaHandler:
             'shutdown_iteration_limit': 2,
             'data_retention_days': 30,
             'backup_enabled': True,
-            'emergency_mode': False
+            'emergency_mode': False,
+            'lora_sf_enabled': True,
+            'lora_sf_drain_per_cycle': 2,
+            'lora_sf_max_depth': 96,
+            'lora_sf_max_age_days': 7,
         }
         
         if os.path.exists(self.config_file):
@@ -209,7 +213,31 @@ class LoRaHandler:
         if self.listener_thread and self.listener_thread.is_alive():
             self.listener_thread.join(timeout=2)
             print("LoRa listener stopped")
-    
+
+    def is_joined(self) -> bool:
+        """Return True if the mDot is currently joined to a LoRaWAN network.
+
+        Holds transmit_lock + the inter-process fcntl lock so the listener
+        thread cannot consume the AT+NJS? response between the write and read.
+        """
+        import re as _re
+        try:
+            with self.transmit_lock:
+                fcntl.lockf(self._lock_fd, fcntl.LOCK_EX)
+                try:
+                    self.ser.reset_input_buffer()
+                    self.ser.write(b'AT+NJS?\r\n')
+                    time.sleep(0.8)
+                    n = self.ser.in_waiting
+                    raw = self.ser.read(n) if n else b''
+                finally:
+                    fcntl.lockf(self._lock_fd, fcntl.LOCK_UN)
+            text = raw.decode('utf-8', errors='replace')
+            nums = _re.findall(r'\d+', text)
+            return bool(nums) and nums[0] == '1'
+        except Exception:
+            return False
+
     def _listen_loop(self):
         """Main listening loop - runs in separate thread"""
         print('Listening for incoming packets')

--- a/tools/lora_store_forward.py
+++ b/tools/lora_store_forward.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""LoRa store-and-forward queue.
+
+Persists capture-cycle payloads to disk when the mDot is not joined so they
+can be retransmitted (trickle-drain, 2/cycle by default) once the mDot rejoins.
+
+Queue directory: $WATERCAM_REPO/data/lora_pending/
+File per cycle:  {captured_at_int}_{counter:06d}.json
+Record schema:
+    {
+        "sensor_hex": "<hex string or null>",
+        "bitmap_hex": "<hex string or null>",
+        "captured_at": <Unix epoch float>,
+        "enqueued_at": <Unix epoch float>
+    }
+
+Timestamps are captured at collection time and baked into the stored hex bytes,
+so retransmitted packets carry the original capture timestamp, not the retransmit
+wall-clock time.
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = os.environ.get("WATERCAM_REPO", "/home/pi/SU-WaterCam")
+DEFAULT_QUEUE_DIR = os.path.join(_REPO_ROOT, "data", "lora_pending")
+DEFAULT_MAX_DEPTH = 96
+DEFAULT_MAX_AGE_DAYS = 7
+
+
+def enqueue(
+    sensor_hex: Optional[str],
+    bitmap_hex: Optional[str],
+    captured_at: float,
+    *,
+    queue_dir: str = DEFAULT_QUEUE_DIR,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+) -> bool:
+    """Persist one capture cycle's payloads to the pending queue.
+
+    If the queue is already at *max_depth*, the oldest entry is dropped to make
+    room.  Returns True on success, False on I/O error (never raises).
+    """
+    try:
+        os.makedirs(queue_dir, exist_ok=True)
+        existing = sorted(f for f in os.listdir(queue_dir) if f.endswith(".json"))
+        while len(existing) >= max_depth:
+            try:
+                os.unlink(os.path.join(queue_dir, existing.pop(0)))
+            except OSError:
+                pass
+        record = {
+            "sensor_hex": sensor_hex,
+            "bitmap_hex": bitmap_hex,
+            "captured_at": captured_at,
+            "enqueued_at": time.time(),
+        }
+        fname = f"{int(captured_at)}_{len(existing):06d}.json"
+        tmp = os.path.join(queue_dir, fname + ".tmp")
+        final = os.path.join(queue_dir, fname)
+        with open(tmp, "w") as fh:
+            json.dump(record, fh)
+        os.replace(tmp, final)
+        logger.info("LoRa S&F: queued %s", fname)
+        return True
+    except OSError as exc:
+        logger.warning("LoRa S&F: enqueue failed: %s", exc)
+        return False
+
+
+def drain(
+    handler,
+    max_packets: int = 2,
+    *,
+    queue_dir: str = DEFAULT_QUEUE_DIR,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+) -> dict:
+    """Transmit up to *max_packets* oldest queued entries via *handler*.
+
+    Both payloads in a record (sensor + bitmap) must transmit successfully
+    before the file is deleted.  Stops on first transmission failure and
+    leaves the remainder for the next cycle.
+
+    Returns {"drained": int, "failed": bool}.
+    """
+    result = {"drained": 0, "failed": False}
+    try:
+        entries = sorted(f for f in os.listdir(queue_dir) if f.endswith(".json"))
+    except FileNotFoundError:
+        return result
+
+    cutoff = time.time() - max_age_days * 86400
+    sent = 0
+
+    for fname in entries:
+        if sent >= max_packets:
+            break
+        path = os.path.join(queue_dir, fname)
+        try:
+            with open(path) as fh:
+                record = json.load(fh)
+        except (OSError, ValueError):
+            logger.warning("LoRa S&F: dropping corrupt file %s", fname)
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            continue
+
+        if record.get("enqueued_at", 0) < cutoff:
+            logger.info("LoRa S&F: evicting stale entry %s", fname)
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            continue
+
+        # Both payloads must succeed; stop on first failure.
+        ok = True
+        for hex_payload in (record.get("sensor_hex"), record.get("bitmap_hex")):
+            if not hex_payload:
+                continue
+            if not handler.transmit(hex_payload):
+                logger.warning("LoRa S&F: drain failed on %s", fname)
+                ok = False
+                break
+
+        if ok:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            result["drained"] += 1
+            sent += 1
+        else:
+            result["failed"] = True
+            break
+
+    return result
+
+
+def queue_depth(queue_dir: str = DEFAULT_QUEUE_DIR) -> int:
+    """Return the number of pending queue files."""
+    try:
+        return sum(1 for f in os.listdir(queue_dir) if f.endswith(".json"))
+    except FileNotFoundError:
+        return 0


### PR DESCRIPTION
## Problem

When the mDot cannot reach the LoRaWAN network (gateway down, out of range), `AT+SENDB` returns `ERROR`. The handler retried 3× then silently discarded the packet. Any outage longer than one wake cycle caused permanent data loss with no recovery path.

## Solution

A file-based store-and-forward queue (`data/lora_pending/`) that persists capture-cycle payloads when the mDot is not joined, then trickle-drains them (2/cycle) the next time the mDot is connected.

## Changes

### `tools/lora_store_forward.py` (new)
File-per-cycle queue, following the same pattern as the IP uplink queue (`transmit_ip.py`).
- `enqueue()` — atomic JSON write (`.tmp` → `os.replace()`), drops oldest when the 96-file cap is reached
- `drain()` — oldest-first; both sensor + bitmap payloads must succeed before deleting a file; stops on first failure, leaving the rest for the next cycle
- `queue_depth()` — count pending files (for logging)

### `tools/lora_handler_concurrent.py`
- New `is_joined()` method: sends `AT+NJS?` while holding `transmit_lock` + fcntl `LOCK_EX` so the listener thread cannot consume the response between the write and read
- Four new `default_config` keys: `lora_sf_enabled`, `lora_sf_drain_per_cycle` (2), `lora_sf_max_depth` (96), `lora_sf_max_age_days` (7)

### `ticktalk_main.py` — `lora_token_with_tracker()`
Three additions:
1. `captured_at = time.time()` at function entry; `data['timestamp']` set from it if GPS didn't provide one — ensures the `00 01` TLV (Unix epoch) is always in stored packets
2. Join check after `get_lora_handler()`: if not joined, encodes both payloads and enqueues them, then returns — skipping all transmission
3. Drain block after bitmap transmit: 2 queued packets/cycle, runs only on the joined path

## Timestamp preservation

Payloads are encoded at capture time and stored as hex strings verbatim. The `00 01` TLV carries the original Unix epoch. Retransmitting the same hex through `AT+SENDB` means the gateway sees the capture timestamp, not the retransmit wall-clock time.

**Bug fixed during review:** The sensor tracker explicitly excludes `'timestamp'` from `sensors_to_transmit` (it's a numeric field but intentionally skipped). The `_sf_data` dict now adds `'timestamp'` unconditionally so stored packets always carry it, even when tracker filtering is active.

## What is NOT queued

TTToken packets (TickTalk routing headers with logical clock ticks) are not stored — the logical ticks reference a clock root that no longer applies after a delay. Only the TLV sensor snapshot and TLV bitmap are queued.

## Test plan

- [ ] Unit: mock `is_joined()` → `False`; verify `enqueue()` called, `transmit()` not called, file appears in `data/lora_pending/`
- [ ] Unit: mock `is_joined()` → `True`, pre-populate queue with 4 files; verify current data transmitted first, then exactly 2 files drained, 2 remain
- [ ] Unit: queue entry with `enqueued_at` older than `max_age_days`; verify it is deleted without being transmitted
- [ ] Live: mDot physically not joined; run a cycle and confirm JSON files accumulate in `data/lora_pending/`
- [ ] Live: mDot rejoins; run two cycles and confirm 2 files are drained per cycle
- [ ] ChirpStack: inspect retransmitted packets — `captured_at` timestamp should match original capture time, not retransmit time

🤖 Generated with [Claude Code](https://claude.com/claude-code)