### PR TITLE
feat: CI-covered unit tests for IMU stable-heading and metadata tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           pip install \
             pytest \
             numpy Pillow brotli \
+            piexif \
             bitstring bitarray \
             pyserial requests \
             pympler \
@@ -50,3 +51,10 @@ jobs:
             tests/test_ip_command_handling.py \
             -v --tb=short \
             -k "not TestLoRaPacketEncoding"
+
+      - name: Run IMU and metadata tests
+        run: |
+          python -m pytest \
+            tests/test_bno055_imu.py \
+            tests/test_add_metadata.py \
+            -v --tb=short

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,11 @@ _stub("gpsd")
 # python-xmp-toolkit (needs exempi C library, not available in CI)
 _stub("libxmp")
 _stub("libxmp.consts")
+# Add attributes so `from libxmp import XMPFiles, XMPMeta, consts` succeeds
+sys.modules["libxmp.consts"].XMP_NS_DC = "http://purl.org/dc/elements/1.1/"
+sys.modules["libxmp"].XMPFiles = MagicMock
+sys.modules["libxmp"].XMPMeta = MagicMock
+sys.modules["libxmp"].consts = sys.modules["libxmp.consts"]
 
 # Preload so patch("tools.compress_segmented.compress_image") resolves at import
 import tools.compress_segmented  # noqa: F401

--- a/tests/test_add_metadata.py
+++ b/tests/test_add_metadata.py
@@ -1,0 +1,192 @@
+"""Tests for add_metadata.add_metadata() EXIF/XMP tagging pipeline."""
+from unittest.mock import MagicMock
+
+import pytest
+
+# Skip entire module when piexif or Pillow are absent (not installed in this env)
+pytest.importorskip("piexif", reason="piexif required for EXIF/XMP tests")
+pytest.importorskip("PIL", reason="Pillow required to create a test JPEG")
+
+import piexif
+import piexif.helper
+from PIL import Image
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tmp_jpeg(tmp_path):
+    """Minimal valid JPEG with empty EXIF sections."""
+    img = Image.new("RGB", (4, 4))
+    path = str(tmp_path / "test.jpg")
+    exif_bytes = piexif.dump({"0th": {}, "Exif": {}, "GPS": {}, "1st": {}})
+    img.save(path, "JPEG", exif=exif_bytes)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _patch_deps(tmp_path, monkeypatch):
+    """Redirect the metadata log, stub GPS, device_id, and IMU for every test."""
+    import tools.add_metadata as am
+    import tools.bno055_imu as imu
+
+    # Point log file at a writable tmp location
+    monkeypatch.setattr(am, "_METADATA_LOG", str(tmp_path / "metadata_log.txt"))
+
+    # GPS: no packet, no formatted data (avoid writing to DATA on GPS errors)
+    monkeypatch.setattr(am, "get_location_with_retry", lambda: (None, None),
+                        raising=False)
+    monkeypatch.setattr(am, "get_loc", lambda: [], raising=False)
+
+    # Device ID: empty by default (overridden per-test as needed)
+    monkeypatch.setattr(am, "_read_device_id", lambda: "")
+
+    # IMU: sensor unavailable by default
+    monkeypatch.setattr(imu, "get_values", lambda: {})
+    monkeypatch.setattr(imu, "get_euler_stable", lambda **kw: {})
+    monkeypatch.setattr(imu, "_get_sensor", lambda: None)
+
+
+@pytest.fixture
+def xmp_capture(monkeypatch):
+    """Intercept XMPFiles/XMPMeta and return the mock xmp object for inspection."""
+    import tools.add_metadata as am
+
+    xmp_instance = MagicMock()
+    xmpfiles_instance = MagicMock()
+    xmpfiles_instance.get_xmp.return_value = xmp_instance
+
+    monkeypatch.setattr(am, "XMPFiles", MagicMock(return_value=xmpfiles_instance))
+    monkeypatch.setattr(am, "XMPMeta", MagicMock())
+    return xmp_instance
+
+
+def _xmp_props(xmp_instance) -> dict:
+    """Return {prop_name: value} from all set_property calls on xmp_instance."""
+    return {c.args[1]: c.args[2] for c in xmp_instance.set_property.call_args_list}
+
+
+def _enable_imu(monkeypatch, heading=70.0, roll=2.0, pitch=-1.0, std=0.3,
+                sys_cal=3, gyro=3, accel=2, mag=3):
+    """Configure IMU mocks to return a complete, stable orientation."""
+    import tools.bno055_imu as imu
+    monkeypatch.setattr(imu, "get_values", lambda: {"Temperature": 25})
+    monkeypatch.setattr(imu, "get_euler_stable", lambda **kw: {
+        "heading_mean": heading, "roll_mean": roll, "pitch_mean": pitch,
+        "heading_std": std, "n_samples": 20,
+    })
+    mock_sensor = MagicMock()
+    mock_sensor.calibration_status = (sys_cal, gyro, accel, mag)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: mock_sensor)
+
+
+# ── XMP orientation ───────────────────────────────────────────────────────────
+
+class TestXMPOrientation:
+    def test_yaw_roll_pitch_written(self, tmp_jpeg, xmp_capture, monkeypatch):
+        _enable_imu(monkeypatch)
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        props = _xmp_props(xmp_capture)
+        assert props["Yaw"] == "70.0"
+        assert props["Roll"] == "2.0"
+        assert props["Pitch"] == "-1.0"
+
+    def test_heading_raw_sensor_frame_tag(self, tmp_jpeg, xmp_capture, monkeypatch):
+        _enable_imu(monkeypatch)
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        assert _xmp_props(xmp_capture).get("HeadingRawSensorFrame") == "true"
+
+    def test_heading_std_dev_written(self, tmp_jpeg, xmp_capture, monkeypatch):
+        _enable_imu(monkeypatch, std=0.42)
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        assert _xmp_props(xmp_capture).get("HeadingStdDev") == "0.42"
+
+    def test_calib_quality_written(self, tmp_jpeg, xmp_capture, monkeypatch):
+        _enable_imu(monkeypatch, sys_cal=3, gyro=3, accel=2, mag=3)
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        props = _xmp_props(xmp_capture)
+        assert props["CalibSys"] == "3"
+        assert props["CalibGyro"] == "3"
+        assert props["CalibAccel"] == "2"
+        assert props["CalibMag"] == "3"
+
+    def test_orientation_absent_when_imu_unavailable(self, tmp_jpeg, xmp_capture):
+        # _patch_deps leaves IMU returning {} — no Yaw/Roll/Pitch should appear
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        props = _xmp_props(xmp_capture)
+        assert "Yaw" not in props
+        assert "Roll" not in props
+        assert "Pitch" not in props
+
+    def test_orientation_absent_when_pitch_is_none(self, tmp_jpeg, xmp_capture,
+                                                    monkeypatch):
+        """Guard must block XMP write when any component is None."""
+        import tools.bno055_imu as imu
+        monkeypatch.setattr(imu, "get_values", lambda: {"Temperature": 25})
+        # pitch_mean is None — the all-or-nothing guard should prevent the write
+        monkeypatch.setattr(imu, "get_euler_stable", lambda **kw: {
+            "heading_mean": 70.0, "roll_mean": 2.0, "pitch_mean": None,
+            "heading_std": 0.3, "n_samples": 15,
+        })
+        mock_sensor = MagicMock()
+        mock_sensor.calibration_status = (3, 3, 2, 3)
+        monkeypatch.setattr(imu, "_get_sensor", lambda: mock_sensor)
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        props = _xmp_props(xmp_capture)
+        assert "Yaw" not in props
+        assert "Roll" not in props
+        assert "Pitch" not in props
+
+
+# ── EXIF UserComment ──────────────────────────────────────────────────────────
+
+class TestEXIFUserComment:
+    def test_user_comment_contains_all_fields(self, tmp_jpeg, xmp_capture,
+                                               monkeypatch):
+        _enable_imu(monkeypatch, heading=70.0, roll=2.0, pitch=-1.0, std=0.3)
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        exif = piexif.load(tmp_jpeg)
+        raw = exif["Exif"].get(piexif.ExifIFD.UserComment)
+        assert raw is not None, "UserComment tag missing from EXIF"
+        comment = piexif.helper.UserComment.load(raw)
+        assert "Yaw 70.0" in comment
+        assert "Roll 2.0" in comment
+        assert "Pitch -1.0" in comment
+        assert "HeadingStd 0.3" in comment
+
+    def test_user_comment_absent_when_no_imu(self, tmp_jpeg, xmp_capture):
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        exif = piexif.load(tmp_jpeg)
+        assert piexif.ExifIFD.UserComment not in exif.get("Exif", {})
+
+
+# ── Device ID ────────────────────────────────────────────────────────────────
+
+class TestDeviceID:
+    def test_device_id_written_to_xmp(self, tmp_jpeg, xmp_capture, monkeypatch):
+        import tools.add_metadata as am
+        monkeypatch.setattr(am, "_read_device_id", lambda: "UFO-006")
+        am.add_metadata(tmp_jpeg)
+        assert _xmp_props(xmp_capture).get("DeviceID") == "UFO-006"
+
+    def test_device_id_written_to_exif_body_serial(self, tmp_jpeg, xmp_capture,
+                                                     monkeypatch):
+        import tools.add_metadata as am
+        monkeypatch.setattr(am, "_read_device_id", lambda: "UFO-006")
+        am.add_metadata(tmp_jpeg)
+        exif = piexif.load(tmp_jpeg)
+        raw = exif["Exif"].get(piexif.ExifIFD.BodySerialNumber)
+        assert raw == b"UFO-006"
+
+    def test_device_id_omitted_when_empty(self, tmp_jpeg, xmp_capture):
+        import tools.add_metadata as am
+        am.add_metadata(tmp_jpeg)
+        assert "DeviceID" not in _xmp_props(xmp_capture)

--- a/tests/test_bno055_imu.py
+++ b/tests/test_bno055_imu.py
@@ -1,0 +1,115 @@
+"""Tests for bno055_imu.get_euler_stable(): circular mean, edge cases."""
+import math
+
+
+class _FakeSensor:
+    """Sensor stub whose euler property cycles through a fixed list of readings."""
+    def __init__(self, readings):
+        self._readings = readings
+        self._idx = 0
+
+    @property
+    def euler(self):
+        val = self._readings[self._idx % len(self._readings)]
+        self._idx += 1
+        return val
+
+
+# ── autouse fixture: suppress time.sleep so tests finish instantly ────────────
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    import tools.bno055_imu as imu
+    monkeypatch.setattr(imu.time, "sleep", lambda s: None)
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+def test_returns_empty_when_sensor_unavailable(monkeypatch):
+    import tools.bno055_imu as imu
+    monkeypatch.setattr(imu, "_get_sensor", lambda: None)
+    assert imu.get_euler_stable() == {}
+
+
+def test_returns_empty_when_all_euler_none(monkeypatch):
+    import tools.bno055_imu as imu
+    sensor = _FakeSensor([(None, None, None)] * 20)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    assert imu.get_euler_stable() == {}
+
+
+def test_circular_mean_basic(monkeypatch):
+    import tools.bno055_imu as imu
+    # Adafruit euler tuple: (heading, roll, pitch)
+    sensor = _FakeSensor([(90.0, 1.0, -2.0)] * 20)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    result = imu.get_euler_stable(n=20)
+    assert abs(result["heading_mean"] - 90.0) < 0.01
+    assert abs(result["roll_mean"] - 1.0) < 0.01     # euler[1] = roll
+    assert abs(result["pitch_mean"] - (-2.0)) < 0.01  # euler[2] = pitch
+    assert result["n_samples"] == 20
+
+
+def test_circular_mean_wraps_at_north(monkeypatch):
+    """Alternating 359°/1° should average to ~0°, not 180° (arithmetic trap)."""
+    import tools.bno055_imu as imu
+    readings = [(359.0, 0.0, 0.0), (1.0, 0.0, 0.0)] * 10
+    sensor = _FakeSensor(readings)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    result = imu.get_euler_stable(n=20)
+    h = result["heading_mean"]
+    # 0° and 360° are both valid representations of north
+    assert h < 1.0 or h > 359.0, f"Expected near 0°, got {h}°"
+
+
+def test_low_std_dev_for_identical_readings(monkeypatch):
+    import tools.bno055_imu as imu
+    sensor = _FakeSensor([(45.0, 0.0, 0.0)] * 20)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    result = imu.get_euler_stable(n=20)
+    assert result["heading_std"] < 0.1
+
+
+def test_higher_std_dev_for_spread_readings(monkeypatch):
+    import tools.bno055_imu as imu
+    # 60° and 120° alternate — circular std should be noticeably above zero
+    readings = [(60.0, 0.0, 0.0), (120.0, 0.0, 0.0)] * 10
+    sensor = _FakeSensor(readings)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    result = imu.get_euler_stable(n=20)
+    assert result["heading_std"] > 5.0
+
+
+def test_pitch_roll_none_when_euler_components_none(monkeypatch):
+    import tools.bno055_imu as imu
+    # heading valid but roll and pitch are None in every sample
+    sensor = _FakeSensor([(90.0, None, None)] * 20)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    result = imu.get_euler_stable(n=20)
+    assert result["heading_mean"] is not None
+    assert result["roll_mean"] is None
+    assert result["pitch_mean"] is None
+
+
+def test_n_samples_reflects_valid_heading_count(monkeypatch):
+    """Only readings with a non-None heading contribute to n_samples."""
+    import tools.bno055_imu as imu
+    readings = [(90.0, 0.0, 0.0)] * 10 + [(None, None, None)] * 10
+    sensor = _FakeSensor(readings)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    result = imu.get_euler_stable(n=20)
+    assert result["n_samples"] == 10
+
+
+def test_sleep_called_once_per_sample(monkeypatch):
+    import tools.bno055_imu as imu
+    sleep_calls = []
+    sensor = _FakeSensor([(90.0, 0.0, 0.0)] * 5)
+    monkeypatch.setattr(imu, "_get_sensor", lambda: sensor)
+    monkeypatch.setattr(imu.time, "sleep", lambda s: sleep_calls.append(s))
+    imu.get_euler_stable(n=5, interval_s=0.015)
+    assert len(sleep_calls) == 5
+    assert all(abs(s - 0.015) < 1e-9 for s in sleep_calls)

--- a/tools/add_metadata.py
+++ b/tools/add_metadata.py
@@ -68,9 +68,12 @@ def change_to_rational(number):
     return (f.numerator, f.denominator)
 
 
+_METADATA_LOG = "/home/pi/SU-WaterCam/data/metadata_log.txt"
+
+
 def add_metadata(image):
     # add metadata to an image
-    DATA = "/home/pi/SU-WaterCam/data/metadata_log.txt"
+    DATA = _METADATA_LOG
 
     # Initialize IMU variables
     roll = None
@@ -134,8 +137,8 @@ def add_metadata(image):
     if device_id:
         exif_data["Exif"][piexif.ExifIFD.BodySerialNumber] = device_id.encode("ascii", errors="replace")
 
-    # Add roll/pitch/yaw to UserComment tag if they exist
-    if roll is not None:
+    # Add roll/pitch/yaw to UserComment tag only when all three are available
+    if roll is not None and pitch is not None and yaw is not None:
         uc = f"Roll {roll} Pitch {pitch} Yaw {yaw}"
         if heading_std is not None:
             uc += f" HeadingStd {heading_std}"
@@ -145,7 +148,7 @@ def add_metadata(image):
     xmp_props: dict = {}
     if device_id:
         xmp_props["DeviceID"] = device_id
-    if roll is not None:
+    if roll is not None and pitch is not None and yaw is not None:
         xmp_props["Roll"] = str(roll)
         xmp_props["Pitch"] = str(pitch)
         # Raw magnetic heading in sensor frame. Mount offset, magnetic declination,

--- a/tools/bno055_imu.py
+++ b/tools/bno055_imu.py
@@ -160,15 +160,15 @@ def get_euler_stable(n: int = 20, interval_s: float = 0.015) -> dict:
     if sensor is None:
         return {}
 
-    headings, pitches, rolls = [], [], []
+    headings, rolls, pitches = [], [], []
     for _ in range(n):
         e = sensor.euler
         if isinstance(e, tuple) and len(e) == 3 and e[0] is not None:
             headings.append(e[0])
             if e[1] is not None:
-                pitches.append(e[1])
+                rolls.append(e[1])    # Adafruit euler[1] = roll
             if e[2] is not None:
-                rolls.append(e[2])
+                pitches.append(e[2])  # Adafruit euler[2] = pitch
         time.sleep(interval_s)
 
     if not headings:


### PR DESCRIPTION
## Summary

- **9 tests** in `test_bno055_imu.py`: cover `get_euler_stable()` — sensor unavailable, all-None euler, circular-mean correctness, north-wrap edge case (arithmetic mean gives 180°, circular gives 0°), std-dev low/high, pitch/roll None propagation, n_samples counting, sleep cadence
- **11 tests** in `test_add_metadata.py`: cover `add_metadata()` — XMP Yaw/Roll/Pitch written only when all three are non-None, `HeadingRawSensorFrame`, `HeadingStdDev`, `CalibSys/Gyro/Accel/Mag`, EXIF UserComment, DeviceID in both XMP and `BodySerialNumber`

### Bug fixes bundled in this PR

| File | Bug | Fix |
|---|---|---|
| `tools/bno055_imu.py` | `get_euler_stable()` collected Adafruit `euler[1]` (roll) into `pitches` list and `euler[2]` (pitch) into `rolls`, swapping `pitch_mean`/`roll_mean` in the returned dict | Swap variable names so `rolls` ← `euler[1]`, `pitches` ← `euler[2]` |
| `tools/add_metadata.py` | Orientation guard was `if roll is not None` — pitch or yaw could silently be `None`, writing `"Pitch None"` into XMP | Tightened to `if roll is not None and pitch is not None and yaw is not None` (both UserComment and XMP) |
| `tools/add_metadata.py` | `DATA` path was a local constant inside `add_metadata()`, making it impossible to redirect in tests | Extracted as module-level `_METADATA_LOG` |

### Infrastructure changes

- `tests/conftest.py`: libxmp stub now provides `XMPFiles`, `XMPMeta`, `consts.XMP_NS_DC` so `from libxmp import …` in `add_metadata.py` succeeds without the native exempi library
- `.github/workflows/ci.yml`: add `piexif` to pip install; add "Run IMU and metadata tests" step

## Test plan

- [x] `tests/test_bno055_imu.py` — 9 tests, all pass locally
- [x] `tests/test_add_metadata.py` — 11 tests, all pass locally
- [x] Existing 5-file CI test suite unchanged — 125 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)